### PR TITLE
Improve network names and grouping

### DIFF
--- a/nengo_spa/ast/base.py
+++ b/nengo_spa/ast/base.py
@@ -54,6 +54,16 @@ class Node(object):
         raise NotImplementedError()
 
 
+class Noop(Node):
+    """Node that has no effect."""
+
+    def connect_to(self, sink, **kwargs):
+        pass
+
+    def construct(self):
+        raise NotImplementedError("Noop nodes cannot be constructed.")
+
+
 class Fixed(Node):
     """Base class for AST nodes that provide a fixed value."""
 

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -45,7 +45,8 @@ def test_binary_operation_on_modules(Simulator, op, suffix, rng):
         sim.run(0.5)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('A' + op + 'B'), skip=0.3)
+        sim.trange(), sim.data[p], vocab.parse('A' + op + 'B'), skip=0.3,
+        atol=0.3)
 
 
 @pytest.mark.parametrize('op', ['+', '-', '*'])

--- a/nengo_spa/modules/assoc_mem.py
+++ b/nengo_spa/modules/assoc_mem.py
@@ -60,8 +60,8 @@ class AssociativeMemory(Network):
 
     def __init__(
             self, selection_net, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label=None, seed=None, add_to_container=None,
-            vocabs=None, **selection_net_args):
+            n_neurons=50, label="Associative memory", seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
         super(AssociativeMemory, self).__init__(
             label=label, seed=seed, add_to_container=add_to_container,
             vocabs=vocabs)
@@ -145,8 +145,8 @@ class IAAssocMem(AssociativeMemory):
     """
     def __init__(
             self, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label=None, seed=None, add_to_container=None,
-            vocabs=None, **selection_net_args):
+            n_neurons=50, label="IA associative memory", seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
         super(IAAssocMem, self).__init__(
             selection_net=IA,
             input_vocab=input_vocab, output_vocab=output_vocab,
@@ -164,8 +164,8 @@ class ThresholdingAssocMem(AssociativeMemory):
     """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label=None, seed=None, add_to_container=None,
-            vocabs=None, **selection_net_args):
+            n_neurons=50, label="Thresholding associative memory", seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
         selection_net_args['threshold'] = threshold
         super(ThresholdingAssocMem, self).__init__(
             selection_net=Thresholding,
@@ -182,8 +182,8 @@ class WTAAssocMem(AssociativeMemory):
     """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label=None, seed=None, add_to_container=None,
-            vocabs=None, **selection_net_args):
+            n_neurons=50, label="WTA associative memory", seed=None,
+            add_to_container=None, vocabs=None, **selection_net_args):
         selection_net_args['threshold'] = threshold
         super(WTAAssocMem, self).__init__(
             selection_net=WTA,

--- a/nengo_spa/modules/bind.py
+++ b/nengo_spa/modules/bind.py
@@ -47,6 +47,7 @@ class Bind(Network):
 
     def __init__(self, vocab=Default, neurons_per_dimension=Default,
                  invert_a=Default, invert_b=Default, **kwargs):
+        kwargs.setdefault('label', "Bind")
         super(Bind, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/compare.py
+++ b/nengo_spa/modules/compare.py
@@ -34,6 +34,7 @@ class Compare(Network):
         'neurons_per_dimension', default=200, low=1, readonly=True)
 
     def __init__(self, vocab=Default, neurons_per_dimension=Default, **kwargs):
+        kwargs.setdefault('label', "Compare")
         super(Compare, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/product.py
+++ b/nengo_spa/modules/product.py
@@ -27,6 +27,7 @@ class Product(Network):
     n_neurons = IntParam('n_neurons', default=200, low=1, readonly=True)
 
     def __init__(self, n_neurons=Default, **kwargs):
+        kwargs.setdefault('label', "Product")
         super(Product, self).__init__(**kwargs)
 
         self.n_neurons = n_neurons

--- a/nengo_spa/modules/scalar.py
+++ b/nengo_spa/modules/scalar.py
@@ -25,6 +25,7 @@ class Scalar(Network):
     n_neurons = IntParam('n_neurons', default=50, low=1, readonly=True)
 
     def __init__(self, n_neurons=Default, **kwargs):
+        kwargs.setdefault('label', "Scalar")
         super(Scalar, self).__init__(**kwargs)
 
         self.n_neurons = n_neurons

--- a/nengo_spa/modules/state.py
+++ b/nengo_spa/modules/state.py
@@ -61,6 +61,7 @@ class State(Network):
                  neurons_per_dimension=Default, feedback=Default,
                  represent_identity=Default,
                  feedback_synapse=Default, **kwargs):
+        kwargs.setdefault('label', "State")
         super(State, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/thalamus.py
+++ b/nengo_spa/modules/thalamus.py
@@ -125,7 +125,7 @@ class Thalamus(Network):
         self.input = self.actions.input
         self.output = self.actions.output
 
-    def construct_gate(self, index, net, label=None):
+    def construct_gate(self, index, bias, label=None):
         """Construct a gate ensemble.
 
         The gate neurons have no activity when the action is selected, but are
@@ -137,8 +137,8 @@ class Thalamus(Network):
         ----------
         index : int
             Index to identify the gate.
-        net : nengo.Network
-            Network to which to add the channel.
+        bias : :class:`nengo.Network`
+            Node providing a bias input of 1.
         label : str, optional
             Label for the gate.
 
@@ -149,14 +149,11 @@ class Thalamus(Network):
         """
         if label is None:
             label = 'gate[%d]' % index
-        with net:
-            intercepts = Uniform(self.threshold_gate, 1)
-            self.gates[index] = gate = nengo.Ensemble(
-                self.neurons_gate, dimensions=1, intercepts=intercepts,
-                label=label, encoders=[[1]] * self.neurons_gate)
-            if not hasattr(net, 'bias'):
-                net.bias = nengo.Node([1], label="bias")
-            nengo.Connection(net.bias, gate, synapse=None)
+        intercepts = Uniform(self.threshold_gate, 1)
+        self.gates[index] = gate = nengo.Ensemble(
+            self.neurons_gate, dimensions=1, intercepts=intercepts,
+            label=label, encoders=[[1]] * self.neurons_gate)
+        nengo.Connection(bias, gate, synapse=None)
 
         self.gate_in_connections[index] = nengo.Connection(
             self.actions.ensembles[index], self.gates[index],

--- a/nengo_spa/modules/transcode.py
+++ b/nengo_spa/modules/transcode.py
@@ -162,6 +162,7 @@ class Transcode(Network):
     def __init__(
             self, function=Default, input_vocab=Default, output_vocab=Default,
             size_in=Default, size_out=Default, **kwargs):
+        kwargs.setdefault('label', "Transcode")
         super(Transcode, self).__init__(**kwargs)
 
         # Vocabs need to be set before function which accesses vocab for

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from nengo_spa.actions import ifmax as actions_ifmax
 from nengo_spa.actions import ModuleInput
-from nengo_spa.ast.base import Node
+from nengo_spa.ast.base import Node, Noop
 from nengo_spa.ast.dynamic import (
     input_network_registry, input_vocab_registry, ModuleOutput,
     output_vocab_registry)
@@ -154,6 +154,11 @@ def ifmax(name, condition, *actions):
         actions = (condition,) + actions
         condition = name
         name = None
+
+    if condition == 0:
+        condition = Noop(TScalar)
+    else:
+        condition = as_ast_node(condition)
 
     return actions_ifmax(name, as_ast_node(condition), *actions)
 

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -61,7 +61,8 @@ class SemanticPointer(Fixed):
         return nengo.Connection(self.construct(), sink, **kwargs)
 
     def construct(self):
-        return nengo.Node(self.v)
+        return nengo.Node(
+            self.v, label="Semantic Pointer ({}d)".format(len(self)))
 
     def normalized(self):
         """Normalize the Semantic Pointer and return it as a new object.

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -335,6 +335,16 @@ def test_action_selection_enforces_connections_to_be_part_of_action():
                     state1 >> state2
 
 
+def test_action_selection_is_not_built_on_exception():
+    with spa.Network():
+        state1 = spa.State(16)
+        state2 = spa.State(32)
+        with pytest.raises(SpaTypeError):
+            with ActionSelection() as action_sel:
+                spa.ifmax(1., state1 >> state2)
+    assert not action_sel.built
+
+
 def test_naming_of_actions():
     with spa.Network():
         state1 = spa.State(16)


### PR DESCRIPTION
**Motivation and context:**
This is an attempt to improve the naming and grouping of modules; mainly for a better display in the Nengo GUI. 

### Naming
* All Nengo SPA modules get a default label. This label, unfortunately, takes precedence even when the module is assigned to a variable in Nengo GUI, i.e. `name = spa.State(64)` will display the name 'State' in Nengo GUI, not 'name'. The obvious workaround is `name = spa.State(64, label='name')`.
* Symbolic expression will display as such under the generated nodes (this was already the case prior to this PR). Example: `spa.sym.A * spa.sym.B * 0.3' will display as 'A*B*0.3'.
* Non-symbolic Semantic Pointer nodes will be label with 'Semantic Pointer (XXd)` where XX is the dimensionality.
* The utility nodes for basal ganglia inputs (the `ifmax` return value) are currently unlabeled. The user will not really interact with these as long as they are not assigned to a variable. So this make sense imo.

### Grouping

* Everything in the context of an action selection object gets now grouped into a network. I'm not sure whether that's better or worse. Unfortunately, this also includes all connections, so these won't be displayed in Nengo GUI until the network is 'opened'.
* Everything else gets shoved into the network where it is defined (as before). This allows the user to easily group things manually into separate networks. It, however, puts the connections again into the same network which can hide them in Nengo GUI.

Improvements on this grouping might hard because everything gets constructed immediately. For example if an `a*b` gets constructed, it is not known if it is part of `a*b >> state1` or `(a*b) - c * d >> state2`. Thus, there isn't really a way to make decisions based on the context without changing ownership of network components after the fact. One also has to keep in mind, that expressions can be used in multiple places, e.g. `tmp = a * b; tmp >> state1; tmp - c * d >> state2`.

It is also not necessarily clear to me how things should be grouped optimally if we had complete freedom. It might change depending on context. 

Addresses #126 and #127.


Let me know what you think of these things. Requested a review from @bjkomer too as he was intending to use the new SPA syntax himself.

**Interactions with other PRs:**
none

**How has this been tested?**
Looked at it in Nengo GUI.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
Further improvements? Discussion?