### PR TITLE
Allow scalar Nengo objects in action rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Release History
 
 **Added**
 
+- One-dimensional outputs of Nengo objects can be used as scalars in action
+  rules.
+  (`#139 <https://github.com/nengo/nengo_spa/issues/139>`_,
+  `#157 <https://github.com/nengo/nengo_spa/pull/157>`_)
 - Syntactic sugar for complex symbolic expressions:
   ``nengo_spa.sym('A + B * C')``.
   (`#138 <https://github.com/nengo/nengo_spa/issues/138>`_,

--- a/docs/examples/custom_module.ipynb
+++ b/docs/examples/custom_module.ipynb
@@ -15,7 +15,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
   },
   "name": ""
  },
@@ -49,7 +49,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Implementing a SPA module is easy:\n",
+      "Implementing a SPA module requires a few steps:\n",
       "\n",
       "1. Implement a class inheriting from `spa.Network`.\n",
       "2. Use `VocabularyOrDimParam` to declare class variables for storing vocublary parameters. This will allow the usage of integer dimensions instead of vocabularies without any further additions.\n",
@@ -102,7 +102,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 6
+     "prompt_number": 2
     },
     {
      "cell_type": "markdown",
@@ -122,16 +122,18 @@
       "    model.config[GatedMemory].neurons_per_dimension = 150\n",
       "    \n",
       "    spa_in = spa.Transcode(\"OKAY\", output_vocab=dimensions)\n",
+      "    gate_in = nengo.Node(lambda t: 1 if t < 0.1 else 0)\n",
+      "\n",
       "    g_mem = GatedMemory(dimensions)\n",
       "    \n",
       "    # It can be in routing rules\n",
       "    spa_in >> g_mem\n",
-      "    0 >> g_mem.input_gate"
+      "    gate_in >> g_mem.input_gate"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 8
+     "prompt_number": 3
     }
    ],
    "metadata": {}

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -44,6 +44,8 @@ def as_ast_node(obj):
         # Trying to create weakref on access of weak dict can raise TypeError
         vocab = output_vocab_registry[output]
     except (KeyError, TypeError) as cause:
+        if getattr(output, 'size_out', 0) == 1:
+            return ModuleOutput(output, TScalar)
         err = SpaTypeError("{} was not registered as a SPA output.".format(
             output))
         err.__suppress_context__ = True

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -223,6 +223,27 @@ def test_assignment_of_dynamic_scalar(Simulator, rng):
     assert_allclose(sim.data[p][sim.trange() > 0.3], 0.5, atol=0.2)
 
 
+@pytest.mark.parametrize('source,use_ens', [
+    ('nengo.Node(0.5)', False),
+    ('nengo.Node([0., 0.5, 1.])[1]', False),
+    ('nengo.Node(0.5)', True)])
+def test_assignment_of_nengo_scalar(source, use_ens, Simulator, rng):
+    with spa.Network() as model:
+        source = eval(source)
+        if use_ens:
+            ens = nengo.Ensemble(50, 1)
+            nengo.Connection(source, ens)
+            source = ens
+        sink = spa.Scalar()
+        source >> sink
+        p = nengo.Probe(sink.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.5)
+
+    assert_allclose(sim.data[p][sim.trange() > 0.3], 0.5, atol=0.2)
+
+
 def test_assignment_of_dynamic_pointer(Simulator, rng):
     vocab = spa.Vocabulary(16, rng=rng)
     vocab.populate('A')

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -188,7 +188,7 @@ def test_assignment_of_fixed_scalar(Simulator, rng):
         0.5 >> sink
         p = nengo.Probe(sink.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.5)
 
     assert_allclose(sim.data[p][sim.trange() > 0.3], 0.5, atol=0.2)
@@ -203,7 +203,7 @@ def test_assignment_of_pointer_symbol(Simulator, rng):
         PointerSymbol('A') >> sink
         p = nengo.Probe(sink.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.5)
 
     assert sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
@@ -217,7 +217,7 @@ def test_assignment_of_dynamic_scalar(Simulator, rng):
         source >> sink
         p = nengo.Probe(sink.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.5)
 
     assert_allclose(sim.data[p][sim.trange() > 0.3], 0.5, atol=0.2)
@@ -233,7 +233,7 @@ def test_assignment_of_dynamic_pointer(Simulator, rng):
         source >> sink
         p = nengo.Probe(sink.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.5)
 
     assert sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
@@ -251,7 +251,7 @@ def test_non_default_input_and_output(Simulator, rng):
         b.output >> bind.input_b
         p = nengo.Probe(bind.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(0.5)
 
     assert sp_close(sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.3)
@@ -281,7 +281,7 @@ def test_action_selection(Simulator, rng):
         p_scalar = nengo.Probe(scalar.output, synapse=0.03)
         p_pointer = nengo.Probe(pointer.output, synapse=0.03)
 
-    with nengo.Simulator(model) as sim:
+    with Simulator(model) as sim:
         sim.run(3.)
 
     t = sim.trange()


### PR DESCRIPTION
**Motivation and context:**
Allowing standard Nengo objects for scalars in action rules simplifies writing these rules, especially when routed by the action selection system. (Otherwise connections and gates have to be created manually.)

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
