### PR TITLE
State similarity in max similarity warning.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Release History
   ``nengo_spa.sym('A + B * C')``.
   (`#138 <https://github.com/nengo/nengo_spa/issues/138>`_,
   `#159 <https://github.com/nengo/nengo_spa/pull/159>`_)
+- Include the achieved similarity in warning issued when desired maximum
+  similarity could not be obtained.
+  (`#117 <https://github.com/nengo/nengo_spa/issues/117>`_,
+  `#158 <https://github.com/nengo/nengo_spa/pull/158>`_)
 
 
 

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -127,9 +127,9 @@ class Vocabulary(Mapping):
         else:
             warnings.warn(
                 'Could not create a semantic pointer with '
-                'max_similarity=%1.2f (D=%d, M=%d)'
+                'max_similarity=%1.2f (D=%d, M=%d, similarity=%1.2f)'
                 % (self.max_similarity, self.dimensions,
-                   len(self._key2idx)))
+                   len(self._key2idx), best_sim))
         return best_p
 
     def __contains__(self, key):


### PR DESCRIPTION
**Motivation and context:**
When the max similarity criterion in a vocab is violated, it is useful to know what the actual max. simularity is.

Closes #117.

**Interactions with other PRs:**
none

**How has this been tested?**
```python
import nengo_spa as spa
v = spa.Vocabulary(32)
for i in range(30):
    v.populate('V' + str(i))
```

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.