### PR TITLE
Add complex symbolic expression syntactic sugar.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Release History
 0.4.1 (unreleased)
 ==================
 
+**Added**
+
+- Syntactic sugar for complex symbolic expressions:
+  ``nengo_spa.sym('A + B * C')``.
+  (`#138 <https://github.com/nengo/nengo_spa/issues/138>`_,
+  `#159 <https://github.com/nengo/nengo_spa/pull/159>`_)
 
 
 

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -1,5 +1,7 @@
 """AST classes for symbolic operations."""
 
+import re
+
 import nengo
 import numpy as np
 
@@ -141,10 +143,18 @@ class PointerSymbolFactory(object):
     Use the `.sym` instance of this class to create *PointerSymbols* like so::
 
         sym.foo  # creates PointerSymbol('foo')
+
+    To create more complex symbolic expressions the following syntax is
+    supported too::
+
+        sym('foo + bar * baz')  # creates PointerSymbol('foo+bar*baz')
     """
 
     def __getattribute__(self, key):
         return PointerSymbol(key)
+
+    def __call__(self, expr):
+        return PointerSymbol(re.sub(r'\s+', '', expr))
 
 
 sym = PointerSymbolFactory()

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -119,3 +119,9 @@ def test_pointer_symbol_factory():
     ps = sym.A
     assert isinstance(ps, PointerSymbol)
     assert ps.expr == 'A'
+
+
+def test_pointer_symbol_factory_expressions():
+    ps = sym('A + B * C')
+    assert isinstance(ps, PointerSymbol)
+    assert ps.expr == (sym.A + sym.B * sym.C).expr


### PR DESCRIPTION
**Motivation and context:**
That is, allow spa.sym(expr) where expr is a string with the expression. This allows to write
```python
spa.sym('A + B * C')
```
instead of
```python
spa.sym.A + spa.sym.B * spa.sym.C
```

Closes #138.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
