### PR TITLE
Add support for hierarchies of vocabularies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,15 @@ Release History
 0.5.1 (unreleased)
 ==================
 
+**Added**
+
+- Methods ``join_vocabs`` any ``pair_vocabs`` for construction vocabularies
+  from smaller vocabularies. Furthermore, these vocabularies and subset
+  vocabularies will keep track of their hierarchical relationships to reduce
+  the number of required ``reinterpret`` operations.
+  (`#79 <https://github.com/nengo/nengo_spa/issues/79>`_,
+  `#162 <https://github.com/nengo/nengo_spa/pull/162>`_)
+
 
 0.5.0 (June 1, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,9 +41,6 @@ Release History
   similarity could not be obtained.
   (`#117 <https://github.com/nengo/nengo_spa/issues/117>`_,
   `#158 <https://github.com/nengo/nengo_spa/pull/158>`_)
-- Possibility to name Vocabulary instances for debugging.
-  (`#163 <https://github.com/nengo/nengo_spa/issues/163>`_,
-  `#165 <https://github.com/nengo/nengo_spa/pull/165>`_)
 
 **Changed**
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -14,4 +14,5 @@ of how ``nengo_spa`` works.
    examples/spa_sequence
    examples/spa_sequence_routed
    examples/spa_parser
+   examples/combining_vocabularies
    examples/vocabulary_casting

--- a/docs/examples/combining_vocabularies.ipynb
+++ b/docs/examples/combining_vocabularies.ipynb
@@ -1,0 +1,315 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nengodev",
+   "language": "python",
+   "name": "nengodev"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  },
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Combining vocabularies\n",
+      "\n",
+      "Sometimes a model will have distinct vocabularies, for example one for shapes and one for colors, but in certain places you might need to combine these vocabularies into larger vocabularies. This examples demonstrates different use cases and possibilities to do so."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "%matplotlib inline\n",
+      "\n",
+      "import nengo\n",
+      "import nengo_spa as spa"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Subsets\n",
+      "\n",
+      "It is possible to create a subset from a vocabulary containing only specific keys. This can be helpful for excluding some Semantic Pointers from a cleanup (associative) memory."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "vocab = spa.Vocabulary(64)\n",
+      "vocab.populate('A; B; C; X; Y; Z')\n",
+      "\n",
+      "with spa.Network() as model:\n",
+      "    stimulus = spa.Transcode('(A + X).normalized()', output_vocab=vocab)\n",
+      "    cleanup = spa.ThresholdingAssocMem(0.3, vocab.create_subset(['A', 'B', 'C']))\n",
+      "    stimulus >> cleanup\n",
+      "    p = nengo.Probe(cleanup.output, synapse=0.03)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(0.5)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.plot(sim.trange(), spa.similarity(sim.data[p], vocab))\n",
+      "plt.xlabel(\"Time [s]\")\n",
+      "plt.ylabel(\"Similarity\")\n",
+      "plt.legend(vocab.keys())"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Union of vocabularies\n",
+      "\n",
+      "In the previous example we started with the complete vocabulary and derived the subset from it. Sometimes it is easier to start out with the smaller vocabularies and derive the larger one from it. To create the union of two vocabularies use the function `combine_vocabs`. By default, it will check that the constraint on the maximum similarity is not exceeded in the combined vocabulary."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "abc_vocab = spa.Vocabulary(64)\n",
+      "abc_vocab.populate('A; B; C')\n",
+      "\n",
+      "xyz_vocab = spa.Vocabulary(64)\n",
+      "xyz_vocab.populate('X; Y; Z')\n",
+      "\n",
+      "combined_vocab = spa.combine_vocabs((abc_vocab, xyz_vocab))\n",
+      "\n",
+      "with spa.Network() as model:\n",
+      "    stimulus = spa.Transcode('(A + X).normalized()', output_vocab=combined_vocab)\n",
+      "    cleanup = spa.ThresholdingAssocMem(0.3, abc_vocab)\n",
+      "    stimulus >> cleanup\n",
+      "    p = nengo.Probe(cleanup.output, synapse=0.03)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(0.5)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.plot(sim.trange(), spa.similarity(sim.data[p], combined_vocab))\n",
+      "plt.xlabel(\"Time [s]\")\n",
+      "plt.ylabel(\"Similarity\")\n",
+      "plt.legend(combined_vocab.keys())"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 12
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Combinations of bound Semantic Pointers\n",
+      "\n",
+      "Assume we construct simple scene representations like `s = RED * CIRCLE + BLUE * SQUARE` and manipulate them (for example `s * (~RED * BLUE + ~BLUE * RED)` to swap colors). This introduces quite some noise that we might want to cleanup, but the cleanup needs to be to bound pairs of Semantic Pointers. Let us start by defining vocabularies for colors and shapes."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "v_colors = spa.Vocabulary(64)\n",
+      "v_colors.populate('RED; BLUE')\n",
+      "\n",
+      "v_shapes = spa.Vocabulary(64)\n",
+      "v_shapes.populate('CIRCLE; SQUARE')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 93
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Then we can create a vocabulary of bound pairs. Note that by default `_` is used to combine the keys."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "v_colored_objs = spa.pair_vocabs((v_colors, v_shapes))\n",
+      "print(list(v_colored_objs.keys()))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 94
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with spa.Network() as model:\n",
+      "    scene = spa.State(v_colored_objs)\n",
+      "    spa.sym('RED_CIRCLE + BLUE_SQUARE') >> scene\n",
+      "    \n",
+      "    manipulation = spa.State(spa.combine_vocabs((v_colors, v_shapes)))\n",
+      "    spa.sym('~RED * BLUE + ~BLUE * RED') >> manipulation\n",
+      "    \n",
+      "    cleanup = spa.ThresholdingAssocMem(0.2, v_colored_objs, function=lambda x: x > 0) \n",
+      "    scene * manipulation.reinterpret(v_colored_objs) >> cleanup\n",
+      "    \n",
+      "    p_in = nengo.Probe(cleanup.input, synapse=0.03)\n",
+      "    p_out = nengo.Probe(cleanup.output, synapse=0.03)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 95
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with nengo.Simulator(model) as sim:\n",
+      "    sim.run(0.5)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 96
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.figure(figsize=(12, 4))\n",
+      "\n",
+      "plt.subplot(1, 2, 1)\n",
+      "plt.plot(sim.trange(), spa.similarity(sim.data[p_in], v_colored_objs))\n",
+      "plt.title(\"Before cleanup\")\n",
+      "plt.xlabel(\"Time [s]\")\n",
+      "plt.ylabel(\"Similarity\")\n",
+      "plt.legend(v_colored_objs.keys(), loc='upper left')\n",
+      "\n",
+      "plt.subplot(1, 2, 2)\n",
+      "plt.plot(sim.trange(), spa.similarity(sim.data[p_out], v_colored_objs))\n",
+      "plt.title(\"After cleanup\")\n",
+      "plt.xlabel(\"Time [s]\")\n",
+      "plt.ylabel(\"Similarity\")"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 97
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Tracking of vocabulary relationships\n",
+      "\n",
+      "When using `create_subset`, `combine_vocabs`, and `pair_vocabs`, the vocabularies track how they are related. That means modules using sub-/supersets of vocabularies can be connected without explicit `reinterpret`. Same when doing a circular convolution of two modules with different vocabularies. For example, the following is valid:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "v1 = spa.Vocabulary(64)\n",
+      "v1.populate('A; B')\n",
+      "\n",
+      "v2 = spa.Vocabulary(64)\n",
+      "v2.populate('C; D')\n",
+      "\n",
+      "combined = spa.combine_vocabs((v1, v2))\n",
+      "paired = spa.pair_vocabs((v1, v2))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 47
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with spa.Network() as model:\n",
+      "    state1 = spa.State(v1)\n",
+      "    state2 = spa.State(v2)\n",
+      "    \n",
+      "    state_combined = spa.State(combined)\n",
+      "    state1 >> state_combined  # the vocabularies of the state differ, but are in a subset/superset relation\n",
+      "    state_combined >> state2\n",
+      "    \n",
+      "    bound = spa.State(paired)\n",
+      "    state1 * state2 >> bound  # state1 and state2 have different vocabularies,\n",
+      "                              # but produce the vocabulary of bind with circular convolution"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 49
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}
+

--- a/docs/examples/combining_vocabularies.ipynb
+++ b/docs/examples/combining_vocabularies.ipynb
@@ -39,6 +39,7 @@
      "input": [
       "%matplotlib inline\n",
       "\n",
+      "import matplotlib.pyplot as plt\n",
       "import nengo\n",
       "import nengo_spa as spa"
      ],

--- a/docs/modules/nengo_spa.vocab.rst
+++ b/docs/modules/nengo_spa.vocab.rst
@@ -11,3 +11,4 @@ nengo\_spa\.vocab
       VocabularyMap
       VocabularyMapParam
       VocabularyOrDimParam
+      combine_vocabs

--- a/docs/modules/nengo_spa.vocab.rst
+++ b/docs/modules/nengo_spa.vocab.rst
@@ -12,3 +12,4 @@ nengo\_spa\.vocab
       VocabularyMapParam
       VocabularyOrDimParam
       combine_vocabs
+      pair_vocabs

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -15,7 +15,7 @@ from nengo_spa.modules import (
     Thalamus,
     Transcode)
 from nengo_spa.network import create_inhibit_node, ifmax, Network
-from nengo_spa.vocab import Vocabulary
+from nengo_spa.vocab import combine_vocabs, pair_vocabs, Vocabulary
 
 
 __copyright__ = "2013-2018, Applied Brain Research"

--- a/nengo_spa/ast/base.py
+++ b/nengo_spa/ast/base.py
@@ -19,6 +19,26 @@ def infer_types(*nodes):
     return type_
 
 
+def infer_paired_types(a, b):
+    """Infers the for pair of nodes allowing for mismatched vocabularies.
+
+    This determines the most specific type for given nodes. If it is a specific
+    vocabulary, this vocabulary will be set for all less specific vocabulary
+    types (but not scalar types) on the given node. Then the type will be
+    returned.
+
+    If both nodes have a `.TVocabulary` type, but different vocabularies,
+    a `.TVocabulary` type representing the pairing of these two vocabularies
+    is returned.
+    """
+    both_tvocab = (isinstance(a.type, TVocabulary) and
+                   isinstance(b.type, TVocabulary))
+    if both_tvocab and a.type != b.type:
+        from nengo_spa.vocab import LazyVocabPairing
+        return TVocabulary(LazyVocabPairing((a.type.vocab, b.type.vocab)))
+    return infer_types(a, b)
+
+
 class Node(object):
     """Base class for nodes in the AST for Nengo SPA operations.
 

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -6,10 +6,12 @@ import nengo
 from nengo.utils.compat import is_number
 import numpy as np
 
-from nengo_spa.ast.base import infer_types, Node, TypeCheckedBinaryOp
+from nengo_spa.ast.base import (
+    infer_types, infer_paired_types, Node, TypeCheckedBinaryOp)
 from nengo_spa.ast.symbolic import FixedScalar, PointerSymbol, Symbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.types import TAnyVocab, TScalar, TAnyVocabOfDim, TVocabulary
+from nengo_spa.vocab import LazyVocabPairing
 
 
 BasalGangliaRealization = None
@@ -66,8 +68,12 @@ class DynamicNode(Node):
     def __rsub__(self, other):
         return (-self) + other
 
-    def _mul_with_fixed(self, other):
-        infer_types(self, other)
+    def _mul_with_fixed(self, other, swap_inputs=False):
+        if swap_inputs:
+            type_ = infer_paired_types(other, self)
+        else:
+            type_ = infer_paired_types(self, other)
+
         if other.type == TScalar:
             tr = other.value
         elif self.type == TScalar and other.type == TAnyVocab:
@@ -81,10 +87,14 @@ class DynamicNode(Node):
                 tr = other.evaluate().get_convolution_matrix()
         else:
             raise AssertionError("Unexpected node type in multiply.")
-        return Transformed(self, tr, self.type)
+        return Transformed(self, tr, type_)
 
     def _mul_with_dynamic(self, other, swap_inputs=False):
-        type_ = infer_types(self, other)
+        if swap_inputs:
+            type_ = infer_paired_types(other, self)
+        else:
+            type_ = infer_paired_types(self, other)
+
         if type_ == TScalar:
             mul = ProductRealization()
         elif self.type == TScalar or other.type == TScalar:
@@ -111,7 +121,7 @@ class DynamicNode(Node):
     @binary_node_op
     def __rmul__(self, other):
         if isinstance(other, Symbol):
-            return self._mul_with_fixed(other)
+            return self._mul_with_fixed(other, swap_inputs=True)
         else:
             return self._mul_with_dynamic(other, swap_inputs=True)
 

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -11,7 +11,6 @@ from nengo_spa.ast.base import (
 from nengo_spa.ast.symbolic import FixedScalar, PointerSymbol, Symbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.types import TAnyVocab, TScalar, TAnyVocabOfDim, TVocabulary
-from nengo_spa.vocab import LazyVocabPairing
 
 
 BasalGangliaRealization = None

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -6,7 +6,8 @@ import nengo
 from nengo.utils.compat import is_number
 import numpy as np
 
-from nengo_spa.ast.base import infer_types, Fixed, TypeCheckedBinaryOp
+from nengo_spa.ast.base import (
+    infer_types, infer_paired_types, Fixed, TypeCheckedBinaryOp)
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.pointer import SemanticPointer
 from nengo_spa.types import TAnyVocab, TScalar, TVocabulary
@@ -105,12 +106,12 @@ class PointerSymbol(Symbol):
 
     @symbolic_op
     def __mul__(self, other):
-        type_ = infer_types(self, other)
+        type_ = infer_paired_types(self, other)
         return PointerSymbol(self.expr + '*' + other.expr, type_)
 
     @symbolic_op
     def __rmul__(self, other):
-        type_ = infer_types(self, other)
+        type_ = infer_paired_types(other, self)
         return PointerSymbol(other.expr + '*' + self.expr, type_)
 
     def dot(self, other):

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -117,7 +117,7 @@ def test_binding_of_paired_modules(Simulator, rng):
         sim.run(0.5)
 
     assert sp_close(
-        sim.trange(), sim.data[p], v1['A'] * v2['B'], skip=0.3)
+        sim.trange(), sim.data[p], v1['A'] * v2['B'], skip=0.3, atol=0.3)
     assert (id(v1), id(v2)) in x.type.vocab.factors
 
 

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -83,6 +83,22 @@ def test_multiply_fixed_scalar_and_pointer_symbol(rng):
     assert_equal(node.output, vocab.parse('2 * A').v)
 
 
+def test_binding_with_paired_vocabs(rng):
+    v1 = spa.Vocabulary(16, rng=rng)
+    v1.populate('A')
+    v2 = spa.Vocabulary(16, rng=rng)
+    v2.populate('B')
+
+    tv1 = TVocabulary(v1)
+    tv2 = TVocabulary(v2)
+
+    with spa.Network():
+        x = PointerSymbol('A', tv1) * PointerSymbol('B', tv2)
+        node = x.construct()
+    assert_equal(node.output, (v1['A'] * v2['B']).v)
+    assert (id(v1), id(v2)) in x.type.vocab.factors
+
+
 def test_fixed_dot(rng):
     vocab = spa.Vocabulary(16, rng=rng)
     vocab.populate('A; B')

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -3,7 +3,8 @@ from nengo.exceptions import ValidationError
 from nengo.utils.compat import is_integer, is_number, range
 import numpy as np
 
-from nengo_spa.ast.base import Fixed, infer_types, TypeCheckedBinaryOp
+from nengo_spa.ast.base import (
+    Fixed, infer_types, infer_paired_types, TypeCheckedBinaryOp)
 from nengo_spa.types import TAnyVocab, TScalar, TVocabulary
 
 
@@ -162,7 +163,7 @@ class SemanticPointer(Fixed):
 
     def convolve(self, other):
         """Return the circular convolution of two SemanticPointers."""
-        type_ = infer_types(self, other)
+        type_ = infer_paired_types(self, other)
         vocab = None if type_ == TAnyVocab else type_.vocab
         n = len(self)
         x = np.fft.irfft(

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -7,6 +7,7 @@ import nengo_spa as spa
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.examine import similarity
 from nengo_spa.network import create_inhibit_node
+from nengo_spa.testing import sp_close
 from nengo_spa.vocab import VocabularyMap
 
 
@@ -155,6 +156,24 @@ def test_casting_vocabs(d1, d2, method, lookup, Simulator, plt, rng):
     plt.ylabel("Similarity")
 
     assert np.mean(spa.similarity(sim.data[p][t], v)) > 0.8
+
+
+def test_auto_subset_vocab_casting(Simulator, rng):
+    v1 = spa.Vocabulary(32, rng=rng)
+    v1.populate('A; B')
+    v2 = v1.create_subset(['A'])
+
+    with spa.Network() as model:
+        a = spa.State(v2)
+        b = spa.State(v1)
+        spa.sym.A >> a
+        a >> b
+        p = nengo.Probe(b.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.5)
+
+    assert sp_close(sim.trange(), sim.data[p], v1['A'], skip=0.3)
 
 
 def test_copy_spa(RefSimulator):

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -199,8 +199,7 @@ def test_ops_preserve_vocab(op):
     assert x.vocab is v
 
 
-@pytest.mark.parametrize('op', (
-    'a+b', 'a-b', 'a*b', 'a.dot(b)', 'a.compare(b)'))
+@pytest.mark.parametrize('op', ('a+b', 'a-b', 'a.dot(b)', 'a.compare(b)'))
 def test_ops_check_vocab_compatibility(op):
     a = SemanticPointer(50, vocab=Vocabulary(50))  # noqa: F841
     b = SemanticPointer(50, vocab=Vocabulary(50))  # noqa: F841

--- a/nengo_spa/tests/test_types.py
+++ b/nengo_spa/tests/test_types.py
@@ -32,3 +32,17 @@ def test_coercion_errors():
     with pytest.raises(SpaTypeError) as err:
         coerce_types(Type('x'), Type('y'))
     assert "Incompatible types" in str(err.value)
+
+
+def test_vocab_hierarchy():
+    vocab = Vocabulary(16)
+    vocab.populate('A; B')
+    subvocab = vocab.create_subset(['A'])
+
+    vocab_type = TVocabulary(vocab)
+    subvocab_type = TVocabulary(subvocab)
+
+    assert coerce_types(vocab_type, subvocab_type) == vocab_type
+
+    subvocab.populate('C')
+    assert coerce_types(vocab_type, subvocab_type) == vocab_type

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -12,8 +12,8 @@ from nengo_spa import Vocabulary
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.pointer import Identity, SemanticPointer
 from nengo_spa.vocab import (
-    combine_vocabs, pair_vocabs, VocabularyMap, VocabularyMapParam,
-    VocabularyOrDimParam)
+    combine_vocabs, LazyVocabPairing, pair_vocabs, VocabularyMap,
+    VocabularyMapParam, VocabularyOrDimParam)
 
 
 def test_add(rng):
@@ -315,9 +315,9 @@ def test_vocabulary_or_dim_param():
 
 
 def test_combine_vocabs(rng):
-    base_vocab = Vocabulary(16, rng)
+    base_vocab = Vocabulary(16, rng=rng)
     base_vocab.populate('A; B; C; D')
-    v1 = Vocabulary(16)
+    v1 = Vocabulary(16, rng=rng)
     for k in ['A', 'B']:
         v1.add(k, base_vocab[k].reinterpret(v1))
     v2 = Vocabulary(16)
@@ -332,10 +332,10 @@ def test_combine_vocabs(rng):
     assert combined in v2.supersets
 
 
-def test_combine_vocabs_shared_keys():
-    v1 = Vocabulary(16)
+def test_combine_vocabs_shared_keys(rng):
+    v1 = Vocabulary(16, rng=rng)
     v1.populate('A')
-    v2 = Vocabulary(16)
+    v2 = Vocabulary(16, rng=rng)
     v2.populate('A')
 
     with pytest.raises(ValidationError):
@@ -350,10 +350,10 @@ def test_combine_vocabs_differing_dimensions():
         combine_vocabs((v1, v2))
 
 
-def test_combine_vocabs_checks_similarity():
-    v1 = Vocabulary(16)
+def test_combine_vocabs_checks_similarity(rng):
+    v1 = Vocabulary(16, rng=rng)
     v1.populate('A')
-    v2 = Vocabulary(16)
+    v2 = Vocabulary(16, rng=rng)
     v2.add('B', v1['A'].reinterpret(v2))
 
     combine_vocabs((v1, v2), check_similarity=False)  # no warning
@@ -362,9 +362,9 @@ def test_combine_vocabs_checks_similarity():
 
 
 def test_pair_vocabs(rng):
-    v1 = Vocabulary(16)
+    v1 = Vocabulary(16, rng=rng)
     v1.populate('A; B')
-    v2 = Vocabulary(16)
+    v2 = Vocabulary(16, rng=rng)
     v2.populate('A; C')
 
     paired = pair_vocabs((v1, v2), check_similarity=False)
@@ -376,6 +376,31 @@ def test_pair_vocabs(rng):
     assert (id(v1), id(v2)) in paired.factors
 
 
+def test_pair_vocabs_hierarchical(rng):
+    v1 = Vocabulary(16, rng=rng)
+    v1.populate('A; B')
+    v2 = Vocabulary(16, rng=rng)
+    v2.populate('C; D')
+    v3 = Vocabulary(16, rng=rng)
+    v3.populate('E; F')
+
+    print('0')
+    p0 = pair_vocabs((v1, v2), check_similarity=False)
+    print('1')
+    p1 = pair_vocabs((p0, v3), check_similarity=False)
+    print('2')
+    p2 = pair_vocabs((v1, v2, v3), check_similarity=False)
+
+    assert len(p1) == len(p2) == 8
+    assert p1.keys() == p2.keys()
+    assert tuple(p1.keys()) == tuple('_'.join(x) for x in itertools.product(
+        ('A', 'B'), ('C', 'D'), ('E', 'F')))
+    assert np.all(p1.vectors == p2.vectors)
+    assert (id(p0), id(v3)) in p1.factors
+    assert (id(v1), id(v2), id(v3)) in p1.factors
+    assert (id(v1), id(v2), id(v3)) in p2.factors
+
+
 def test_pair_vocabs_differing_dimensions():
     v1 = Vocabulary(16)
     v2 = Vocabulary(32)
@@ -384,11 +409,65 @@ def test_pair_vocabs_differing_dimensions():
         combine_vocabs((v1, v2))
 
 
-def test_pair_vocabs_checks_similarity():
-    v1 = Vocabulary(16)
+def test_pair_vocabs_checks_similarity(rng):
+    v1 = Vocabulary(16, rng=rng)
     v1.populate('A')
-    v2 = Vocabulary(16)
+    v2 = Vocabulary(16, rng=rng)
     v2.populate('B')
 
     with pytest.warns(UserWarning, match="Max. similarity"):
         pair_vocabs((v1, v2), max_similarity=0.)
+
+
+def test_lazy_vocab_pairing(rng):
+    v1 = Vocabulary(16, rng=rng)
+    v1.populate('A; B')
+    v2 = Vocabulary(16, rng=rng)
+    v2.populate('A; C')
+
+    paired = LazyVocabPairing((v1, v2))
+    assert len(paired) == 4
+    for i, (k1, k2) in enumerate(itertools.product(('A', 'B'), ('A', 'C'))):
+        k = k1 + '*' + k2
+        assert k in paired
+        assert np.all(paired[k].v == (
+            v1[k1].reinterpret(paired) * v2[k2].reinterpret(paired)).v)
+        assert np.all(paired[k].v == paired.vectors[i])
+    assert (id(v1), id(v2)) in paired.factors
+
+
+def test_lazy_vocab_hierarchical_pairing(rng):
+    v1 = Vocabulary(16, rng=rng)
+    v1.populate('A; B')
+    v2 = Vocabulary(16, rng=rng)
+    v2.populate('C; D')
+    v3 = Vocabulary(16, rng=rng)
+    v3.populate('E; F')
+
+    p1 = LazyVocabPairing((LazyVocabPairing((v1, v2)), v3))
+    p2 = LazyVocabPairing((v1, v2, v3))
+
+    assert len(p1) == len(p2) == 8
+    assert p1.keys() == p2.keys()
+    assert tuple(p1.keys()) == tuple('*'.join(x) for x in itertools.product(
+        ('A', 'B'), ('C', 'D'), ('E', 'F')))
+    assert np.all(p1.vectors == p2.vectors)
+    assert (id(v1), id(v2), id(v3)) in p1.factors
+    assert (id(v1), id(v2), id(v3)) in p2.factors
+
+
+def test_lazy_vocab_conversion(rng):
+    v1 = Vocabulary(16, rng=rng)
+    v1.populate('A; B')
+    v2 = Vocabulary(16, rng=rng)
+    v2.populate('A; C')
+
+    lazy_paired = LazyVocabPairing((v1, v2))
+    paired = lazy_paired.to_vocabulary()
+    for k1, k2 in itertools.product(('A', 'B'), ('A', 'C')):
+        k = k1 + '_' + k2
+        assert k in paired
+        assert np.all(paired[k].v == (
+            v1[k1].reinterpret(paired) * v2[k2].reinterpret(paired)).v)
+    assert (id(v1), id(v2)) in paired.factors
+    assert paired in lazy_paired.supersets

--- a/nengo_spa/types.py
+++ b/nengo_spa/types.py
@@ -41,6 +41,9 @@ class Type(object):
             return NotImplemented
         return self.__class__ is other.__class__ and self.name == other.name
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __lt__(self, other):
         return other.__gt__(self)
 

--- a/nengo_spa/types.py
+++ b/nengo_spa/types.py
@@ -125,7 +125,8 @@ class TVocabulary(Type):
         if not isinstance(other, Type):
             return NotImplemented
         return (super(TVocabulary, self).__eq__(other) and
-                self.vocab is other.vocab)
+                (self.vocab is other.vocab or
+                 any(f in other.vocab.factors for f in self.vocab.factors)))
 
     def __gt__(self, other):
         if not isinstance(other, Type):

--- a/nengo_spa/types.py
+++ b/nengo_spa/types.py
@@ -130,7 +130,9 @@ class TVocabulary(Type):
     def __gt__(self, other):
         if not isinstance(other, Type):
             return NotImplemented
-        return other <= TAnyVocabOfDim(self.vocab.dimensions)
+        return other <= TAnyVocabOfDim(self.vocab.dimensions) or (
+            isinstance(other, TVocabulary) and
+            self.vocab in other.vocab.supersets)
 
 
 def coerce_types(*types):

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -478,7 +478,7 @@ class LazyVocabPairing(Mapping):
         def __init__(self, msg):
             super(LazyVocabPairing._CallToVocab, self).__init__(
                 (msg + " Call to_vocabulary() first to create a proper " +
-                "Vocublary instance.").strip())
+                 "Vocublary instance.").strip())
 
     class _CannotAddPointer(_CallToVocab):
         def __init__(self):

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -360,6 +360,38 @@ class Vocabulary(Mapping):
 def combine_vocabs(
         vocabs, strict=True, max_similarity=0.1, rng=None,
         check_similarity=True):
+    """Combines vocabularies into a single vocabulary.
+
+    The keys in vocabularies that are being combined need to be unique.
+
+    Parameters
+    ----------
+    vocabs : sequence of `.Vocabulary`
+        Vocabularies to combine.
+    strict : bool, optional
+        Whether to automatically create missing semantic pointers when parsing
+        expressions with the returned vocabulary object. If a
+        non-strict vocabulary is asked for a pointer that does not exist within
+        the vocabulary, the missing pointer will be automatically added to the
+        vocabulary. A strict vocabulary will throw an error if asked for a
+        pointer that does not exist in the vocabulary.
+    max_similarity : float, optional
+        When randomly generating pointers, ensure that the cosine of the
+        angle between the new pointer and all existing pointers is less
+        than this amount. If the system is unable to find such a pointer
+        after 100 tries, a warning message is printed.
+    rng : numpy.random.RandomState, optional
+        The random number generator to use to create new vectors.
+    check_similarity : bool, optional
+        If *True*, the function will give a warning if the similarity of any
+        two Semantic Pointers in the combined vocabulary exceeds
+        *max_similarity*.
+
+    Returns
+    -------
+    Vocabulary
+        Combined vocabulary.
+    """
     if not all(v.dimensions == vocabs[0].dimensions for v in vocabs):
         raise ValueError(
             "Can only combine vocabularies with equal dimensionality.")

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -79,6 +79,8 @@ class Vocabulary(Mapping):
         self.rng = rng
         self.name = name
 
+        self.supersets = []
+
     @property
     def vectors(self):
         v = self._vectors.view()
@@ -91,7 +93,7 @@ class Vocabulary(Mapping):
             self.dimensions, name, id(self))
 
     def create_pointer(self, attempts=100, transform=None):
-        """Create a new semantic pointer and add it to the vocabulary.
+        """Create a new semantic pointer (without adding it to the vocabulary).
 
         This will take into account the `max_similarity` attribute.  If a
         pointer satisfying max_similarity is not generated after the specified
@@ -349,6 +351,8 @@ class Vocabulary(Mapping):
         # Copy over the new keys
         for key in keys:
             subset.add(key, self[key].reinterpret(subset))
+
+        subset.supersets.append(self)
 
         return subset
 


### PR DESCRIPTION
**Motivation and context:**
Sometimes it can be useful to construct larger vocabularies from smaller ones. This PR adds according functionality. Adding this functionality turned out to require more careful thought than I expected and adds quite a bit of complexity. So there can be an argument made to not merge this feature.

This PR adds two functions `combine_vocabs` and `pair_vocabs`. `combine_vocabs` creates a new vocabulary that contains all the keys of the vocabularies passed in. This requires that there are no duplicate names. By default it checks for the max. similarity constraint to avoid surprises, but this can be deactivated (because the only way to ensure it is to chose sufficient dimensionalities and hope that the god of randomness is on your side ;) ). 'pair_vocabs' creates a new vocabulary with all the bound pairs. Duplicate names are allowed (because new keys will be constructed). Again a check for the max. similarity is performed that  can be disabled. The keys of the paired vocabulary are the concatenation of the keys of the input vocabularies with a some symbol, by default `_`. So if there are SPs `A` and `B` in vocabs 1 and 2, the paired key would be `A_B`. Note that we cannot use `*` because it is not allowed in a SP name. I'm not sure whether I am happy with the name `pair_vocabs`, so other suggestions are welcome. But I would like to avoid anything `circular convolution` as other binding operations might be supported in the future.

Because these functions create new vocabularies, updates to the original vocabularies are not reflected. I think this is less surprising than if they were reflected and makes it easier to add further pointers to any vocabulary but exclude them from the combine or pair operation.

Technically, the creation of new vocabularies also means that they are all independent and thus incompatible types. This turns out to be rather awkward and requiring a lot of `reinterpret` calls in the action syntax. Thus, an attempt is made to keep track of the relations of vocabularies (and this is were the main complexities come into play). Each vocabulary tracks it supersets (i.e. other vocabularies that contain the same set of keys and potential other keys). Adding pointers to a subset will not destroy the superset relation. I think this is reasonable especially consdering the larger picture of type compatibility. Two vocabularies that are in a subset/superset relation are compatible with each other in either direction. Thus a connection can be made from a module with the subset vocabulary to a module with the superset vocabulary or the other way around (just allowing one direction would require a larger number of changes given how the type system works).

For the pairing of vocabularies, each vocabulary stores a list of factors which are the IDs (we don't want to keep a reference to allow garbage collection) of vocabularies that would generate this paired vocabulary. There might be multiple such combinations. So far writing `a * b` was not possible if `a` and `b` had different vocabularies, but now we want this to result in the paired vocabulary and allow the routing to a module that uses such a vocabulary. However, the code doing the work to implement `a * b` does not have access to the place where `a * b` gets routed and cannot obtain the desired vocab instance. Thus, a `LazyPairedVocab` instance is created which implements the `Vocabulary` interface (or at least some part of it that is important). This allows to access the paired pointers with keys like `A*B`. Note that the actual multiplication operator is used here for technical reasons. It is used to split the key into the subkeys to dynamically calculate the requested vector (with `A_B` it would be unclear if this needs to be split into two subkeys or is a single key in one of the paired vocabularies). The reason for creating theses lazily evaluated vocabularies is that the pairings of vocabularies can makes the vocabulary size grow exponentially and thus we should avoid creating too many of these intermediary vocabs. The `LazyPairedVocab` also provides the factors and it can be checked whether another vocabulary was (or can be) created from the same factors, in which case the vocabularies are compatible and the routing is allowed without explicit `reinterpret`.

Note that when `a` and `b` use the same vocabulary the result will also use the same vocabulary (instead of the vocab paired with itself). If either `a` or `b` has no specific vocabulary assigned, it will be inferred from the other operand and then the previous rule is applied (use the same vocab for the result).

I'm not super happy with the name `LazyPairedVocab`, so other ideas are welcome. I'm also unsure whether to include it in the documenation. Users should usually not instantiate it, but they might end up getting an instance of this class if doing stuff like `x = a * b; x.vocab`, and because it is not a full vocabulary implementation it might behave in surprising ways until converted to a proper vocabulary with `to_vocabulary()`.

**Interactions with other PRs:**
none

**How has this been tested?**
added tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
tbd

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
- [x] Documentation
- [x] Add support for two different vocabs to `Bind`.
- [x] Python 2 compatibility
- [x] Test `create_subset` semantics for superset tracking