### PR TITLE
Allow integer vocabs for associative memories.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Release History
 0.5.1 (unreleased)
 ==================
 
+**Fixed**
+
+- Allow integer values for vocabularies in associative memories.
+  (`#171 <https://github.com/nengo/nengo_spa/pull/171>`_)
+
+
 
 0.5.0 (June 1, 2018)
 ====================

--- a/nengo_spa/modules/assoc_mem.py
+++ b/nengo_spa/modules/assoc_mem.py
@@ -28,9 +28,9 @@ class AssociativeMemory(Network):
         network needs to have an *input* attribute to which the utilities for
         each choice are connected and an *output* attribute from which a
         connection will be created to read the selected output(s).
-    input_vocab: Vocabulary
+    input_vocab: Vocabulary or int
         The vocabulary to match.
-    output_vocab: Vocabulary, optional
+    output_vocab: Vocabulary or int, optional
         The vocabulary to be produced for each match. If
         None, the associative memory will act like an autoassociative memory
         (cleanup memory).
@@ -83,9 +83,10 @@ class AssociativeMemory(Network):
                 "'by-key' or None.", attr='mapping', obj=self)
 
         input_keys = mapping.keys()
-        input_vectors = [input_vocab.parse(key).v for key in input_keys]
+        input_vectors = [self.input_vocab.parse(key).v for key in input_keys]
         output_keys = [mapping[k] for k in input_keys]
-        output_vectors = [output_vocab.parse(key).v for key in output_keys]
+        output_vectors = [
+            self.output_vocab.parse(key).v for key in output_keys]
 
         input_vectors = np.asarray(input_vectors)
         output_vectors = np.asarray(output_vectors)

--- a/nengo_spa/modules/tests/test_assoc_mem.py
+++ b/nengo_spa/modules/tests/test_assoc_mem.py
@@ -282,3 +282,12 @@ def test_invalid_mapping_string():
             ThresholdingAssocMem(
                 threshold=0.3, input_vocab=16, output_vocab=32,
                 mapping='invalid')
+
+
+@pytest.mark.parametrize('cls_and_args', (
+    (ThresholdingAssocMem, (0.3,)), (WTAAssocMem, (0.3,)), (IAAssocMem, ())))
+def test_int_vocabs(cls_and_args):
+    cls, args = cls_and_args
+    with spa.Network() as model:
+        model.vocabs.get_or_create(32).populate('A')
+        cls(*args, input_vocab=32)  # no assertion, just ensure no exception


### PR DESCRIPTION
**Motivation and context:**
For consistency, this was not working before. Not sure, if we should rather enforce an explicit vocabulary (with better error message) because only pointers already in the vocab at time of instantiation will be considered.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
