### PR TITLE
Enforce mapping argument on associative memories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,12 @@ Release History
 0.6.0 (unreleased)
 ==================
 
+**Changed**
 
+- Require the ``mapping`` argument for associative memories. In addition to
+  dictionaries and the string ``'by-key'``, a sequence of strings can be passed
+  in to create an auto-associative memory.
+  (`#177 <https://github.com/nengo/nengo_spa/pull/177>`_)
 
 
 0.5.2 (July 6, 2018)

--- a/docs/examples/associative_memory.ipynb
+++ b/docs/examples/associative_memory.ipynb
@@ -210,7 +210,7 @@
      "input": [
       "with spa.Network('AssociativeMemory', seed=seed) as model:\n",
       "    # create the AM module\n",
-      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab)\n",
+      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab, mapping=vocab.keys())\n",
       "\n",
       "    # present input to the AM\n",
       "    spa.sym.APPLE >> model.assoc_mem\n",
@@ -338,7 +338,7 @@
      "collapsed": false,
      "input": [
       "with spa.Network('CleanupThreshold', seed=seed) as model:\n",
-      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.7, input_vocab=vocab)\n",
+      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.7, input_vocab=vocab, mapping=vocab.keys())\n",
       "    \n",
       "    (0.9 * spa.sym.APPLE + 0.5 * spa.sym.CHERRY + 0.4 * spa.sym.APRICOT >> \n",
       "        model.assoc_mem)\n",
@@ -374,6 +374,7 @@
      "input": [
       "with spa.Network('CleanupThreshold', seed=seed) as model:\n",
       "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.7, input_vocab=vocab,\n",
+      "                                               mapping=vocab.keys(),\n",
       "                                               function=lambda x: x > 0.)\n",
       "    \n",
       "    (0.9 * spa.sym.APPLE + 0.5 * spa.sym.CHERRY + 0.4 * spa.sym.APRICOT >> \n",
@@ -409,7 +410,7 @@
      "collapsed": false,
      "input": [
       "with spa.Network('Cleanup', seed=seed) as model:\n",
-      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab)\n",
+      "    model.assoc_mem = spa.ThresholdingAssocMem(threshold=0.3, input_vocab=vocab, mapping=vocab.keys())\n",
       "    \n",
       "    (0.9 * spa.sym.APPLE + 0.85 * spa.sym.CHERRY + 0.7 * spa.sym.APRICOT >>\n",
       "        model.assoc_mem)\n",
@@ -446,6 +447,7 @@
       "    model.assoc_mem = spa.WTAAssocMem(\n",
       "        threshold=0.3,\n",
       "        input_vocab=vocab,\n",
+      "        mapping=vocab.keys(),\n",
       "        function=lambda x: x > 0.)\n",
       "\n",
       "    (0.9 * spa.sym.APPLE + 0.85 * spa.sym.CHERRY + 0.7 * spa.sym.APRICOT >>\n",

--- a/docs/examples/intro.ipynb
+++ b/docs/examples/intro.ipynb
@@ -808,7 +808,7 @@
       "\n",
       "The unbinding of a vector is only an approximate inverse. That means the result will contain some noise that in some cases needs to be removed. This can be done with clean-up or associative memories (a clean-up memory is basically an auto-associative memory). Nengo SPA provides a number of different variants of such associative memories. Here we demonstrate the clean-up with a `ThresholdingAssocMem`. It simply removes all vector components below a certain threshold (here `0.2`).\n",
       "\n",
-      "An associative memory needs to be provided with a vocabulary of all potential vectors that it could clean up to. In this example it is the colors `BLUE` and `RED`, but not `CIRCLE` and `SQUARE`. How to create vocabularies has been shown in the previous section. Here we use a slight variation on this. We acquire the *d*-dimension default vocabulary with `model.vocabs[d]` and create subset with the desired vectors from it.\n",
+      "An associative memory needs to be provided with a vocabulary and all potential Semantic Pointers that it could clean up to with the `mapping` parameter. The `mapping` parameters allows to specify hetero-associative mappings, but here we just provide a sequence of keys which will create an auto-associative mapping.\n",
       "\n",
       "Note that this subset is considered to be a different vocabulary than the default vocabulary itself. That means a simple `result >> am` will not work. But we know that both vocabularies use exactly the same vectors (because we created one as subset from the other) and thus can reinterpret the Semantic Pointer from `result` in the subset vocabulary. This is done with `spa.reinterpret(result) >> am`. In this case we do not need to provide the vocabulary as argument to `spa.reinterpret` because it can be determined from the context. Keep in mind that this might not work in all cases and give an exception. Then you have to explicitly add the vocabulary as argument to `spa.reinterpret`."
      ]
@@ -821,7 +821,7 @@
       "    scene = spa.Transcode('BLUE * CIRCLE + RED * SQUARE', output_vocab=d)\n",
       "    query = spa.Transcode(lambda t: 'CIRCLE' if t < 0.25 else 'SQUARE', output_vocab=d)\n",
       "    result = spa.State(d)\n",
-      "    am = spa.ThresholdingAssocMem(0.2, model.vocabs[d].create_subset(['BLUE', 'RED']))\n",
+      "    am = spa.ThresholdingAssocMem(0.2, input_vocab=d, mapping=['BLUE', 'RED'])\n",
       "    \n",
       "    scene * ~query >> result\n",
       "    spa.reinterpret(result) >> am\n",

--- a/nengo_spa/modules/assoc_mem.py
+++ b/nengo_spa/modules/assoc_mem.py
@@ -87,6 +87,11 @@ class AssociativeMemory(Network):
         if not hasattr(mapping, 'keys'):
             mapping = {k: k for k in mapping}
 
+        if len(mapping) < 1:
+            raise ValidationError(
+                "At least one item must be provided with the mapping "
+                "argument.", attr='mapping', obj=self)
+
         input_keys = mapping.keys()
         input_vectors = [self.input_vocab.parse(key).v for key in input_keys]
         output_keys = [mapping[k] for k in input_keys]

--- a/nengo_spa/modules/assoc_mem.py
+++ b/nengo_spa/modules/assoc_mem.py
@@ -32,14 +32,14 @@ class AssociativeMemory(Network):
         The vocabulary to match.
     output_vocab: Vocabulary or int, optional
         The vocabulary to be produced for each match. If
-        None, the associative memory will act like an autoassociative memory
+        None, the associative memory will act like an auto-associative memory
         (cleanup memory).
-    mapping: dict or str, optional
+    mapping: dict, str, or sequence of str
         A dictionary that defines the mapping from Semantic Pointers in the
         input vocabulary to Semantic Pointers in the output vocabulary. If set
         to the string ``'by-key'``, the mapping will be done based on the keys
-        of the to vocabularies. If *None*, the associative memory will be
-        autoassociative (cleanup memory).
+        of the to vocabularies. If a sequence is provided, an auto-associative
+        (cleanup) memory with the given set of keys will be created.
     n_neurons : int
         Number of neurons to represent each choice, passed on to the
         *selection_net*.
@@ -75,12 +75,17 @@ class AssociativeMemory(Network):
         self.input_vocab = input_vocab
         self.output_vocab = output_vocab
 
-        if mapping is None or mapping == 'by-key':
-            mapping = {k: k for k in self.input_vocab.keys()}
+        if mapping is None:
+            raise TypeError("Must provide 'mapping' argument.")
+        elif mapping == 'by-key':
+            mapping = self.input_vocab.keys()
         elif is_string(mapping):
             raise ValidationError(
                 "The mapping argument must be a dictionary, the string "
-                "'by-key' or None.", attr='mapping', obj=self)
+                "'by-key' or a sequence of strings.", attr='mapping', obj=self)
+
+        if not hasattr(mapping, 'keys'):
+            mapping = {k: k for k in mapping}
 
         input_keys = mapping.keys()
         input_vectors = [self.input_vocab.parse(key).v for key in input_keys]

--- a/nengo_spa/modules/tests/test_assoc_mem.py
+++ b/nengo_spa/modules/tests/test_assoc_mem.py
@@ -306,3 +306,13 @@ def test_enforces_explicit_mapping(cls_and_args):
         model.vocabs.get_or_create(32).populate('A')
         with pytest.raises(TypeError):
             cls(*args, input_vocab=32)
+
+
+@pytest.mark.parametrize('cls_and_args', (
+    (ThresholdingAssocMem, (0.3,)), (WTAAssocMem, (0.3,)), (IAAssocMem, ())))
+def test_enforces_at_least_one_item(cls_and_args):
+    cls, args = cls_and_args
+    with spa.Network() as model:
+        model.vocabs.get_or_create(32).populate('A')
+        with pytest.raises(ValidationError, message='At least one'):
+            cls(*args, input_vocab=32, mapping=[])


### PR DESCRIPTION
**Motivation and context:**
As discussed [here](https://github.com/nengo/nengo-spa/pull/171#issuecomment-395085499) this makes the `mapping` argument for associative memories required. This makes explicit which vectors are cleaned up and should lead to less surprise that vectors added later to a vocabulary are not included. It also ensures that in the GUI the vectors are added to the vocabulary instead of potentially creating an empty cleanup memory.

Furthermore, as syntactic sugar sequences of strings are allowed as syntactic sugar for `{k: k for k in sequence}`.

**Interactions with other PRs:**
based on #171 (that one provides pure bugfixes, this one provides API changes which require a minor release instead of a bugfix release)

**How has this been tested?**
added tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
