### PR TITLE
Allow non-SPA networks as root network.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,17 @@ Release History
    - Fixed
 
 
+0.5.2 (unreleased)
+==================
+
+**Fixed**
+
+- SPA modules will use the same default vocabularies even if not instantiated
+  in the context of a `spa.Network`.
+  (`#174 <https://github.com/nengo/nengo-spa/issues/174>`_,
+  `#185 <https://github.com/nengo/nengo-spa/pull/185>`_)
+
+
 0.5.1 (June 7, 2018)
 ====================
 

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -194,3 +194,13 @@ def test_instance_config():
         net.config[nengo.Ensemble].set_param(
             'param', nengo.params.BoolParam('param', default=False))
         net.config[ens].param = True
+
+
+def test_no_root_spa_network_required():
+    with nengo.Network():  # nengo.Network, not spa.Network!
+        state = spa.State(16)
+        state2 = spa.State(16)
+        # Next line will raise an exception if the two states do not share
+        # the same vocab. They are supposed to share the vocab despite not
+        # being in a spa.Network.
+        state >> state2


### PR DESCRIPTION
**Motivation and context:**
Closes #174.

Instead of providing an error when accidentally using nengo.Network
and not a spa.Network, this makes it possible to use a nengo.Network.
The main reason the spa.Network was required, was to track the default
vocabularies. This commit adds a dictionary to that allows to store
the default vocabularies associated with root networks.

This is easier than figuring out whether we shoult raise an Exception
(because spa.Network is allowed to be used in nengo.Network by design).

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
