### PR TITLE
Fix non-equality relationship in type system.

### DIFF
--- a/nengo_spa/tests/test_types.py
+++ b/nengo_spa/tests/test_types.py
@@ -32,3 +32,14 @@ def test_coercion_errors():
     with pytest.raises(SpaTypeError) as err:
         coerce_types(Type('x'), Type('y'))
     assert "Incompatible types" in str(err.value)
+
+
+def test_non_equality():
+    v = Vocabulary(16)
+    tv1 = TVocabulary(v)
+    tv2 = TVocabulary(v)
+    tvx = TVocabulary(Vocabulary(16))
+    assert tv1 == tv2
+    assert not (tv1 != tv2)
+    assert tv1 != tvx
+    assert not (tv1 == tvx)

--- a/nengo_spa/types.py
+++ b/nengo_spa/types.py
@@ -41,6 +41,9 @@ class Type(object):
             return NotImplemented
         return self.__class__ is other.__class__ and self.name == other.name
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __lt__(self, other):
         return other.__gt__(self)
 


### PR DESCRIPTION
**Motivation and context:**
The `__ne__` operator is not automatically defined based on `__eq__` in Python 2.

**Interactions with other PRs:**
Cherry-picked from #162 because important enough to be fixed no matter whether and when #162 gets merged.

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
