### PR TITLE
Exclude keywords and unicode from SP names.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Release History
   in the context of a `spa.Network`.
   (`#174 <https://github.com/nengo/nengo-spa/issues/174>`_,
   `#185 <https://github.com/nengo/nengo-spa/pull/185>`_)
+- Disallow Python keywords, including None, True, and False, as well as unicode
+  characters from Python names.
+  (`#188 <https://github.com/nengo/nengo_spa/pull/188>`_,
+  `#187 <https://github.com/nengo/nengo_spa/issues/187>`_)
 
 
 0.5.1 (June 7, 2018)

--- a/nengo_spa/modules/tests/test_assoc_mem.py
+++ b/nengo_spa/modules/tests/test_assoc_mem.py
@@ -251,8 +251,8 @@ def test_am_spa_keys_as_expressions(Simulator, plt, seed, rng):
     t_item2 = (t > 0.175) & (t < 0.2)
 
     # Modify vocabularies (for plotting purposes)
-    vocab_in.add(in_keys[1], vocab_in.parse(in_keys[1]).v)
-    vocab_out.add(out_keys[0], vocab_out.parse(out_keys[0]).v)
+    vocab_in.add('AxB', vocab_in.parse(in_keys[1]).v)
+    vocab_out.add('CxD', vocab_out.parse(out_keys[0]).v)
 
     plt.subplot(2, 1, 1)
     plt.plot(t, similarity(sim.data[in_p], vocab_in))

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -275,7 +275,8 @@ def test_non_default_input_and_output(Simulator, rng):
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.3)
+    assert sp_close(
+        sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.3, atol=0.3)
 
 
 def test_action_selection(Simulator, rng):

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -67,8 +67,15 @@ def test_populate(rng):
     # invalid names: lowercase, unicode
     with pytest.raises(SpaParseError):
         v.populate('x = A')
-    # with pytest.raises(SpaParseError):
-    v.populate(u'Aα = A')
+    with pytest.raises(SpaParseError):
+        v.populate(u'Aα = A')
+
+
+@pytest.mark.parametrize('name', ('None', 'True', 'False'))
+def test_reserved_names(name):
+    v = Vocabulary(16)
+    with pytest.raises(SpaParseError):
+        v.populate(name)
 
 
 def test_populate_with_transform_on_first_vector(rng):

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -1,4 +1,5 @@
 from collections import Mapping
+from keyword import iskeyword
 import re
 import warnings
 
@@ -12,7 +13,8 @@ from nengo_spa.exceptions import SpaParseError
 from nengo_spa.pointer import Identity
 
 
-valid_sp_regex = re.compile('[A-Z][_a-zA-Z0-9]*')
+valid_sp_regex = re.compile('^[A-Z][_a-zA-Z0-9]*$')
+reserved_sp_names = {'None', 'True', 'False'}
 
 
 class Vocabulary(Mapping):
@@ -176,7 +178,8 @@ class Vocabulary(Mapping):
         p : SemanticPointer or array_like
             Semantic Pointer to add.
         """
-        if not valid_sp_regex.match(key):
+        if (not valid_sp_regex.match(key) or iskeyword(key) or
+                key in reserved_sp_names):
             raise SpaParseError(
                 "Invalid Semantic Pointer name {!r}. Valid names are valid "
                 "Python 2 identifiers beginning with a capital letter.".format(


### PR DESCRIPTION
**Motivation and context:**
Because we rely on the Python interpreter for parsing we cannot use Python keywords as Semantic Pointer name. For some reason the test for unicode characters in Semantic Pointer names was commented out even though it shouldn't. Uncommented it and fixed the regex to require a match of the complete name.

Fixes #187.

**Interactions with other PRs:**
none

**How has this been tested?**
existing and added tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
