### PR TITLE
Add parsing for special Semantic Pointers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,11 @@ Release History
   operator.
   (`#190 <https://github.com/nengo/nengo_spa/issues/190>`_,
   `#194 <https://github.com/nengo/nengo_spa/pull/194>`_)
+- The Semantic Pointer names *AbsorbingElement*, *Identity*, and *Zero* now
+  have a special meaning in *Vocabulary* and *nengo_spa.sym* and will return
+  the respective special Semantic Pointers.
+  (`#195 <https://github.com/nengo/nengo_spa/pull/195>`_,
+  `#176 <https://github.com/nengo/nengo_spa/issues/176>`_)
 
 **Changed**
 

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -10,7 +10,7 @@ from nengo_spa import Vocabulary
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.pointer import Identity, SemanticPointer
 from nengo_spa.vocab import (
-    VocabularyMap, VocabularyMapParam, VocabularyOrDimParam)
+    special_sps, VocabularyMap, VocabularyMapParam, VocabularyOrDimParam)
 
 
 def test_add(rng):
@@ -71,11 +71,20 @@ def test_populate(rng):
         v.populate(u'Aα = A')
 
 
-@pytest.mark.parametrize('name', ('None', 'True', 'False'))
+@pytest.mark.parametrize('name', (
+    'None', 'True', 'False', 'Zero', 'AbsorbingElement', 'Identity'))
 def test_reserved_names(name):
     v = Vocabulary(16)
     with pytest.raises(SpaParseError):
         v.populate(name)
+
+
+@pytest.mark.parametrize('name,sp', sorted(special_sps.items()))
+def test_special_sps(name, sp):
+    v = Vocabulary(16)
+    assert name in v
+    assert np.allclose(v[name].v, sp(16).v)
+    assert np.allclose(v.parse(name).v, sp(16).v)
 
 
 def test_populate_with_transform_on_first_vector(rng):


### PR DESCRIPTION
**Motivation and context:**
Addresses #176.

Allows `spa.sym.Zero`, `vocab['Identity']`, and `vocab.parse('AbsorbingElement')` to access special Semantic Pointers. These names won't be listed in `vocab.keys()` or `vocab.vectors`.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.