### PR TITLE
Add support for different binding operations

### DIFF
--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -16,6 +16,8 @@ if [[ "$COMMAND" == "install" ]]; then
     conda install matplotlib scipy
     pip install ghp-import
     pip install -e .[docs]
+elif [[ "$COMMAND" == "check" ]]; then
+    sphinx-build -b linkcheck -vW -D nbsphinx_execute=never docs docs/_build
 elif [[ "$COMMAND" == "run" ]]; then
     rm "$HOME/.ipython/profile_default/ipython_config.py"
     sphinx-build -vW docs docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,12 @@ script:
       .ci/static.sh run;
     elif [[ "$COVERAGE" == "true" ]]; then
       .ci/coverage.sh run;
-    elif [[ "$DOCS" == "true" && -n "$TRAVIS_TAG" ]]; then
-      .ci/docs.sh run;
+    elif [[ "$DOCS" == "true" ]]; then
+      if [[ -n "$TRAVIS_TAG" ]]; then
+        .ci/docs.sh run;
+      else
+        .ci/docs.sh check;
+      fi
     else
       .ci/test.sh run;
     fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,15 @@ Release History
 
 **Added**
 
+- Support for algebras that allow to use binding operations other than circular
+  convolution. This includes an implementation of vector-derived transformation
+  binding (VTB) and the ``nengo_spa.networks.VTB`` network to perform this
+  particular binding operation.
+  (`#69 <https://github.com/nengo/nengo_spa/issues/69>`__,
+  `#198 <https://github.com/nengo/nengo_spa/pull/198>`__)
+- Added a matrix multiplication network ``nengo_spa.networks.MatrixMult`` based
+  on the nengo-extras implementation.
+  (`#198 <https://github.com/nengo/nengo_spa/pull/198>`__)
 - Allow to connect to the utility node returned by `ifmax` with the SPA `>>`
   operator.
   (`#190 <https://github.com/nengo/nengo_spa/issues/190>`_,
@@ -41,6 +50,21 @@ Release History
   dictionaries and the string ``'by-key'``, a sequence of strings can be passed
   in to create an auto-associative memory.
   (`#177 <https://github.com/nengo/nengo_spa/pull/177>`_)
+- Renamed ``input_a`` and ``input_b`` of the ``nengo_spa.Bind`` module to
+  ``input_left`` and ``input_right`` to account for non-commutative binding
+  methods where the order of operands matters. Also, renamed the ``invert_a``
+  and ``invert_b`` arguments to ``unbind_left`` and ``unbind_right`` to reflect
+  that some binding methods might not have inverse vectors, but might still be
+  able to do unbinding.
+  (`#69 <https://github.com/nengo/nengo_spa/issues/69>`__,
+  `#198 <https://github.com/nengo/nengo_spa/pull/198>`__)
+
+**Removed**
+
+- Removed ``nengo_spa.networks.circularconvolution.circconv`` because
+  ``nengo_spa.algebras.CircularConvolutionAlgebra`` provides the same
+  functionality.
+  (`#198 <https://github.com/nengo/nengo_spa/pull/198>`__)
 
 
 0.5.2 (July 6, 2018)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ Filing issues
 -------------
 
 If you find a bug in Nengo SPA, or think that a certain feature is missing,
-please consider `filing an issue <https://github.com/nengo/nengo_spa/issues>`_.
+please consider `filing an issue <https://github.com/nengo/nengo-spa/issues>`_.
 Please search the currently open issues first to see if your bug or feature
 request already exists. If so, feel free to add a comment to the issue
 so that we know that multiple people are affected.

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -30,13 +30,13 @@ Nengo SPA imports several open source libraries.
 
 * `NumPy <http://www.numpy.org/>`_ - Used under
   `BSD license <http://www.numpy.org/license.html>`__
-* `Sphinx <http://sphinx-doc.org/>`_ - Used under
+* `Sphinx <http://www.sphinx-doc.org/en/master>`_ - Used under
   `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
 * `nbsphinx <https://github.com/spatialaudio/nbsphinx>`_ - Used under
   `MIT license <https://github.com/spatialaudio/nbsphinx/blob/master/LICENSE>`__
-* `matplotlib <http://matplotlib.org/>`_ - Used under
-  `modified PSF license <http://matplotlib.org/users/license.html>`__
+* `matplotlib <https://matplotlib.org/>`_ - Used under
+  `modified PSF license <https://matplotlib.org/users/license.html>`__
 * `Jupyter <http://jupyter.org/>`_ - Used under
-  `BSD license <https://github.com/jupyter/jupyter/blob/master/COPYING.rst>`__
-* `pytest <http://pytest.org/latest/>`_ - Used under
-  `MIT license <http://docs.pytest.org/en/latest/license.html>`__
+  `BSD license <https://github.com/jupyter/jupyter/blob/master/LICENSE>`__
+* `pytest <https://docs.pytest.org/en/latest/>`_ - Used under
+  `MIT license <https://docs.pytest.org/en/latest/license.html>`__

--- a/docs/examples/intro_coming_from_legacy_spa.ipynb
+++ b/docs/examples/intro_coming_from_legacy_spa.ipynb
@@ -377,8 +377,8 @@
       "    bind = spa.Bind(d)\n",
       "    \n",
       "    spa.sym.A * spa.sym.B >> state\n",
-      "    state >> bind.input_a\n",
-      "    ~spa.sym.B >> bind.input_b\n",
+      "    state >> bind.input_left\n",
+      "    ~spa.sym.B >> bind.input_right\n",
       "\n",
       "    p = nengo.Probe(bind.output, synapse=0.03)"
      ],
@@ -476,8 +476,8 @@
       "    spa_input = spa.Transcode(stimulus_fn, output_vocab=vocab)\n",
       "    \n",
       "    spa_input >> state\n",
-      "    state >> bind.input_a\n",
-      "    ~spa.sym.B >> bind.input_b\n",
+      "    state >> bind.input_left\n",
+      "    ~spa.sym.B >> bind.input_right\n",
       "\n",
       "    p = nengo.Probe(bind.output, synapse=0.03)"
      ],

--- a/docs/modules/nengo_spa.algebras.rst
+++ b/docs/modules/nengo_spa.algebras.rst
@@ -1,0 +1,12 @@
+nengo\_spa\.algebras
+====================
+
+.. automodule:: nengo_spa.algebras
+   :members:
+   :imported-members:
+
+   .. autosummary::
+
+      AbstractAlgebra
+      CircularConvolutionAlgebra
+      VtbAlgebra

--- a/docs/modules/nengo_spa.testing.rst
+++ b/docs/modules/nengo_spa.testing.rst
@@ -7,5 +7,5 @@ nengo\_spa\.testing
    .. rubric:: Functions
 
    .. autosummary::
-   
-      sp_close
+
+      assert_sp_close

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -6,3 +6,4 @@ User Guide
    examples/intro.ipynb
    examples/intro_coming_from_legacy_spa.ipynb
    examples/custom_module.ipynb
+   user_guide/algebras

--- a/docs/user_guide/algebras.rst
+++ b/docs/user_guide/algebras.rst
@@ -1,0 +1,40 @@
+Algebras
+--------
+
+Nengo SPA uses elementwise addition for superposition and circular convolution
+for binding (`.CircularConvolutionAlgebra`) by default. But other choices are
+viable. In Nengo SPA we call such a specific choice of such operators an
+*algebra*. It is easy to change the algebra that is used by Nengo SPA as it is
+tied to the vocabulary. To use a different algebra is suffices to manually
+create a vocabulary with the desired algebra and use this in your model::
+
+    import nengo
+    import nengo_spa as spa
+
+    vocab = spa.Vocabulary(64, algebra=VtbAlgebra())
+
+    with spa.Network() as model:
+        a = spa.State(vocab)
+        b = spa.State(vocab)
+        c = spa.State(vocab)
+        a * b >> c
+
+In this example the `.VtbAlgebra` (vector-derived transformation binding, VTB)
+is used to bind *a* and *b*.
+
+Note that circular convolution is commutative, i.e. :math:`a \circledast
+b = b \circledast a`, but in general this is not true for all algebras. In
+particular, the vector-derived transformation binding is not commutative. That
+means you have to pay attention from which side things are bound and unbound.
+Moreover, when given :math:`\mathcal{B}(\mathcal{B}(a, b), c)`, it is not
+possible to directly unbind :math:`a`, but :math:`c` has to be unbound first
+because VTB is not associative.
+
+Custom algebras can be implemented by implementing the `.AbstractAlgebra`
+interface. The process involves implementing math versions of the superposition
+and binding operator, functions for obtaining specific matrices (such as
+inverting a vector), functions for obtaining special elements like the identity
+vector, and functions to provide neural implementations of the superposition and
+binding. A partial implementation is possible, but will prevent the usage of
+certain parts of Nengo SPA. For example, when not providing neural
+implementations, only non-neural math can be performed.

--- a/docs/user_guide/algebras.rst
+++ b/docs/user_guide/algebras.rst
@@ -2,7 +2,7 @@ Algebras
 --------
 
 Nengo SPA uses elementwise addition for superposition and circular convolution
-for binding (`.CircularConvolutionAlgebra`) by default. But other choices are
+for binding (`.CircularConvolutionAlgebra`) by default. However, other choices are
 viable. In Nengo SPA we call such a specific choice of such operators an
 *algebra*. It is easy to change the algebra that is used by Nengo SPA as it is
 tied to the vocabulary. To use a different algebra is suffices to manually
@@ -11,7 +11,7 @@ create a vocabulary with the desired algebra and use this in your model::
     import nengo
     import nengo_spa as spa
 
-    vocab = spa.Vocabulary(64, algebra=VtbAlgebra())
+    vocab = spa.Vocabulary(64, algebra=spa.algebras.VtbAlgebra())
 
     with spa.Network() as model:
         a = spa.State(vocab)
@@ -23,9 +23,9 @@ In this example the `.VtbAlgebra` (vector-derived transformation binding, VTB)
 is used to bind *a* and *b*.
 
 Note that circular convolution is commutative, i.e. :math:`a \circledast
-b = b \circledast a`, but in general this is not true for all algebras. In
-particular, the vector-derived transformation binding is not commutative. That
-means you have to pay attention from which side things are bound and unbound.
+b = b \circledast a`, but this is not true for all algebras. In
+particular, the VTB is not commutative. That
+means you have to pay attention from which side vectors are bound and unbound.
 Moreover, when given :math:`\mathcal{B}(\mathcal{B}(a, b), c)`, it is not
 possible to directly unbind :math:`a`, but :math:`c` has to be unbound first
 because VTB is not associative.

--- a/docs/user_guide/spa_intro.rst
+++ b/docs/user_guide/spa_intro.rst
@@ -130,7 +130,7 @@ example of an SPA to date.
 
 Let us consider how the model would perform a single run of one of the cognitive
 tasks (`see a video of Spaun running this task
-<http://nengo.ca/build-a-brain/task7>`_). This is analogous to the `Raven's
+<https://xchoo.github.io/spaun2.0/>`_). This is analogous to the `Raven's
 Matrix <https://en.wikipedia.org/wiki/Raven's_Progressive_Matrices>`_ task,
 which requires people to figure out a pattern in the input, and apply that
 pattern to new input to produce novel output. For instance given the following
@@ -180,4 +180,4 @@ All of the control-like steps (e.g. “compared with”, “inferred”, and rou
 information through the system), are implemented by a biologically plausible
 basal ganglia model. This is one example of the 8 different tasks that Spaun is
 able to perform. Videos for all tasks can be found `here
-<http://nengo.ca/build-a-brain/spaunvideos/>`_.
+<http://www.nengo.ca/build-a-brain/spaunvideos/>`_.

--- a/docs/user_guide/spa_intro.rst
+++ b/docs/user_guide/spa_intro.rst
@@ -96,6 +96,15 @@ If we want to know the color of the square, we can unbind the *square* vector:
    + \mathit{noise}
 
 
+.. note::
+
+   While circular convolution is the default binding operation in Nengo SPA and
+   has been used widely, other choices are possible, potentially better suited
+   for certain tasks, and also supported by Nengo SPA. The :doc:`algebras`
+   section explains how to use other binding operations. Choices included in
+   Nengo SPA are documented in the API documentation of `nengo_spa.algebras`.
+
+
 An example: Spaun
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/user_guide/spa_intro.rst
+++ b/docs/user_guide/spa_intro.rst
@@ -99,10 +99,11 @@ If we want to know the color of the square, we can unbind the *square* vector:
 .. note::
 
    While circular convolution is the default binding operation in Nengo SPA and
-   has been used widely, other choices are possible, potentially better suited
-   for certain tasks, and also supported by Nengo SPA. The :doc:`algebras`
-   section explains how to use other binding operations. Choices included in
-   Nengo SPA are documented in the API documentation of `nengo_spa.algebras`.
+   has been used widely, other choices are possible. Other choices supported by
+   Nengo SPA are potentially better suited for certain tasks. The
+   :doc:`algebras` section explains how to use other binding operations. Choices
+   included in Nengo SPA are documented in the API documentation of
+   `nengo_spa.algebras`.
 
 
 An example: Spaun
@@ -180,4 +181,4 @@ All of the control-like steps (e.g. “compared with”, “inferred”, and rou
 information through the system), are implemented by a biologically plausible
 basal ganglia model. This is one example of the 8 different tasks that Spaun is
 able to perform. Videos for all tasks can be found `here
-<http://www.nengo.ca/build-a-brain/spaunvideos/>`_.
+<https://xchoo.github.io/spaun2.0/videos.html>`_.

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -12,6 +12,7 @@ from nengo_spa.modules import (
     Product,
     Scalar,
     State,
+    Superposition,
     Thalamus,
     Transcode)
 from nengo_spa.network import create_inhibit_node, ifmax, Network

--- a/nengo_spa/algebras/__init__.py
+++ b/nengo_spa/algebras/__init__.py
@@ -1,0 +1,2 @@
+from .cconv import CircularConvolutionAlgebra
+from .vtb import VtbAlgebra

--- a/nengo_spa/algebras/__init__.py
+++ b/nengo_spa/algebras/__init__.py
@@ -1,2 +1,5 @@
+"""Algebras define the specific superposition and (un)binding operations."""
+
+from .base import AbstractAlgebra
 from .cconv import CircularConvolutionAlgebra
 from .vtb import VtbAlgebra

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -1,0 +1,231 @@
+class AbstractAlgebra(object):
+    """Abstract base class for algebras.
+
+    Custom algebras can be defined by implementing the interface of this
+    abstract base class.
+    """
+
+    def is_valid_dimensionality(self, d):
+        """Checks whether *d* is a valid vector dimensionality.
+
+        Parameters
+        ----------
+        d : int
+            Dimensionality
+
+        Returns
+        -------
+        bool
+            *True*, if *d* is a valid vector dimensionality for the use with
+            the algebra.
+        """
+        raise NotImplementedError()
+
+    def make_unitary(self, v):
+        """Returns a unitary vector based on the vector *v*.
+
+        A unitary vector does not change the length of a vector it is bound to.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to base unitary vector on.
+
+        Returns
+        -------
+        ndarray
+            Unitary vector.
+        """
+        raise NotImplementedError()
+
+    def superpose(self, a, b):
+        """Returns the superposition of *a* and *b*.
+
+        This is commonly elementwise addition.
+
+        Parameters
+        ----------
+        a : (d,) ndarray
+            Left operand in superposition.
+        b : (d,) ndarray
+            Right operand in superposition.
+
+        Returns
+        -------
+        (d,) ndarray
+            Superposed vector.
+        """
+        raise NotImplementedError()
+
+    def bind(self, a, b):
+        """Returns the binding of *a* and *b*.
+
+        The resulting vector should in most cases be dissimilar to both inputs.
+
+        Parameters
+        ----------
+        a : (d,) ndarray
+            Left operand in binding.
+        b : (d,) ndarray
+            Right operand in binding.
+
+        Returns
+        -------
+        (d,) ndarray
+            Bound vector.
+        """
+        raise NotImplementedError()
+
+    def invert(self, v):
+        """Invert vector *v*.
+
+        A vector bound to its inverse will result in the identity vector.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to invert.
+
+        Returns
+        -------
+        (d,) ndarray
+            Inverted vector.
+        """
+        raise NotImplementedError()
+
+    def get_binding_matrix(self, v, swap_inputs=False):
+        """Returns the transformation matrix for binding with a fixed vector.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Fixed vector to derive binding matrix for.
+        swap_inputs : bool, optional
+            By default the matrix will be such that *v* becomes the *right*
+            operand in the binding. By setting *swap_inputs*, the matrix will
+            be such that *v* becomes the *left* operand. For binding operations
+            that are commutative (such as circular convolution), this has no
+            effect.
+
+        Returns
+        -------
+        (d, d) ndarray
+            Transformation matrix to perform binding with *v*.
+        """
+        raise NotImplementedError()
+
+    def get_inversion_matrix(self, d):
+        """Returns the transformation matrix for inverting a vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality (determines the matrix size).
+
+        Returns
+        -------
+        (d, d) ndarray
+            Transformation matrix to invert a vector.
+        """
+        raise NotImplementedError()
+
+    def implement_superposition(self, n_neurons_per_d, d, n):
+        """Implement neural network for superposing vectors.
+
+        Parameters
+        ----------
+        n_neurons_per_d : int
+            Neurons to use per dimension.
+        d : int
+            Dimensionality of the vectors.
+        n : int
+            Number of vectors to superpose in the network.
+
+        Returns
+        -------
+        tuple
+            Tuple *(net, inputs, output)* where *net* is the implemented
+            `nengo.Network`, *inputs* a sequence of length *n* of inputs to the
+            network, and *output* the network output.
+        """
+        raise NotImplementedError()
+
+    def implement_binding(self, n_neurons_per_d, d, unbind_left, unbind_right):
+        """Implement neural network for binding vectors.
+
+        Parameters
+        ----------
+        n_neurons_per_d : int
+            Neurons to use per dimension.
+        d : int
+            Dimensionality of the vectors.
+        unbind_left : bool
+            Whether the left input should be unbound from the right input.
+        unbind_right : bool
+            Whether the right input should be unbound from the left input.
+
+        Returns
+        -------
+        tuple
+            Tuple *(net, inputs, output)* where *net* is the implemented
+            `nengo.Network`, *inputs* a sequence of the left and the right
+            input in that order, and *output* the network output.
+        """
+        raise NotImplementedError()
+
+    def absorbing_element(self, d):
+        """Return the standard absorbing element of dimensionality *d*.
+
+        An absorbing element will produce a scaled version of itself when bound
+        to another vector. The standard absorbing element is the absorbing
+        element with norm 1.
+
+        Some algebras might not have an absorbing element other than the zero
+        vector. In that case a *NotImplementedError* may be raised.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Standard absorbing element.
+        """
+        raise NotImplementedError()
+
+    def identity_element(self, d):
+        """Return the identity element of dimensionality *d*.
+
+        The identity does not change the vector it is bound to.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Identity element.
+        """
+        raise NotImplementedError()
+
+    def zero_element(self, d):
+        """Return the zero element of dimensionality *d*.
+
+        The zero element produces itself when bound to a different vector.
+        Usually this will be the zero vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Zero element.
+        """
+        raise NotImplementedError()

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -58,8 +58,9 @@ class CircularConvolutionAlgebra(object):
         return node, n * (node,), node
 
     @classmethod
-    def implement_binding(cls, n_neurons_per_d, d, invert_a, invert_b):
-        net = CircularConvolution(n_neurons_per_d, d, invert_a, invert_b)
+    def implement_binding(cls, n_neurons_per_d, d, unbind_left, unbind_right):
+        net = CircularConvolution(
+            n_neurons_per_d, d, unbind_left, unbind_right)
         return net, (net.input_a, net.input_b), net.output
 
     @classmethod

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -6,12 +6,19 @@ from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.networks.circularconvolution import CircularConvolution
 
 
-class _CircularConvolutionAlgebra(AbstractAlgebra):
+class CircularConvolutionAlgebra(AbstractAlgebra):
     """Circular convolution algebra.
 
     Uses element-wise addition for superposition, circular convolution for
     binding with an approximate inverse.
     """
+
+    _instance = None
+
+    def __new__(cls):
+        if type(cls._instance) is not cls:
+            cls._instance = super(CircularConvolutionAlgebra, cls).__new__(cls)
+        return cls._instance
 
     def is_valid_dimensionality(self, d):
         return d > 0
@@ -65,6 +72,3 @@ class _CircularConvolutionAlgebra(AbstractAlgebra):
 
     def zero_element(self, d):
         return np.zeros(d)
-
-
-CircularConvolutionAlgebra = _CircularConvolutionAlgebra()

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -68,6 +68,9 @@ class CircularConvolutionAlgebra(AbstractAlgebra):
         fft_imag = fft_val.imag
         fft_real = fft_val.real
         fft_norms = np.sqrt(fft_imag ** 2 + fft_real ** 2)
+        invalid = fft_norms <= 0.
+        fft_val[invalid] = 1.
+        fft_norms[invalid] = 1.
         fft_unit = fft_val / fft_norms
         return np.array((np.fft.ifft(fft_unit, n=len(v))).real)
 

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -1,0 +1,42 @@
+from nengo.utils.compat import range
+import numpy as np
+
+
+class CircularConvolutionAlgebra(object):
+    """Circular convolution algebra.
+
+    Uses element-wise addition for superposition, circular convolution for
+    binding with an approximate inverse.
+    """
+
+    @classmethod
+    def make_unitary(cls, v):
+        fft_val = np.fft.fft(v)
+        fft_imag = fft_val.imag
+        fft_real = fft_val.real
+        fft_norms = np.sqrt(fft_imag ** 2 + fft_real ** 2)
+        fft_unit = fft_val / fft_norms
+        return np.array((np.fft.ifft(fft_unit, n=len(v))).real)
+
+    @classmethod
+    def superpose(cls, a, b):
+        return a + b
+
+    @classmethod
+    def bind(cls, a, b):
+        n = len(a)
+        if len(b) != n:
+            raise ValueError("Inputs must have same length.")
+        return np.fft.irfft(np.fft.rfft(a) * np.fft.rfft(b), n=n)
+
+    @classmethod
+    def invert(cls, v):
+        return v[-np.arange(len(v))]
+
+    @classmethod
+    def get_binding_matrix(cls, v):
+        D = len(v)
+        T = []
+        for i in range(D):
+            T.append([v[(i - j) % D] for j in range(D)])
+        return np.array(T)

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -2,22 +2,21 @@ import nengo
 from nengo.utils.compat import range
 import numpy as np
 
+from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.networks.circularconvolution import CircularConvolution
 
 
-class CircularConvolutionAlgebra(object):
+class _CircularConvolutionAlgebra(AbstractAlgebra):
     """Circular convolution algebra.
 
     Uses element-wise addition for superposition, circular convolution for
     binding with an approximate inverse.
     """
 
-    @classmethod
-    def is_valid_dimensionality(cls, d):
+    def is_valid_dimensionality(self, d):
         return d > 0
 
-    @classmethod
-    def make_unitary(cls, v):
+    def make_unitary(self, v):
         fft_val = np.fft.fft(v)
         fft_imag = fft_val.imag
         fft_real = fft_val.real
@@ -25,54 +24,47 @@ class CircularConvolutionAlgebra(object):
         fft_unit = fft_val / fft_norms
         return np.array((np.fft.ifft(fft_unit, n=len(v))).real)
 
-    @classmethod
-    def superpose(cls, a, b):
+    def superpose(self, a, b):
         return a + b
 
-    @classmethod
-    def bind(cls, a, b):
+    def bind(self, a, b):
         n = len(a)
         if len(b) != n:
             raise ValueError("Inputs must have same length.")
         return np.fft.irfft(np.fft.rfft(a) * np.fft.rfft(b), n=n)
 
-    @classmethod
-    def invert(cls, v):
+    def invert(self, v):
         return v[-np.arange(len(v))]
 
-    @classmethod
-    def get_binding_matrix(cls, v, swap_inputs=False):
+    def get_binding_matrix(self, v, swap_inputs=False):
         D = len(v)
         T = []
         for i in range(D):
             T.append([v[(i - j) % D] for j in range(D)])
         return np.array(T)
 
-    @classmethod
-    def get_inversion_matrix(cls, d):
+    def get_inversion_matrix(self, d):
         return np.eye(d)[-np.arange(d)]
 
-    @classmethod
-    def implement_superposition(cls, n_neurons_per_d, d, n):
+    def implement_superposition(self, n_neurons_per_d, d, n):
         node = nengo.Node(size_in=d)
         return node, n * (node,), node
 
-    @classmethod
-    def implement_binding(cls, n_neurons_per_d, d, unbind_left, unbind_right):
+    def implement_binding(self, n_neurons_per_d, d, unbind_left, unbind_right):
         net = CircularConvolution(
             n_neurons_per_d, d, unbind_left, unbind_right)
         return net, (net.input_a, net.input_b), net.output
 
-    @classmethod
-    def absorbing_element(cls, d):
+    def absorbing_element(self, d):
         return np.ones(d) / np.sqrt(d)
 
-    @classmethod
-    def identity_element(cls, d):
+    def identity_element(self, d):
         data = np.zeros(d)
         data[0] = 1.
         return data
 
-    @classmethod
-    def zero_element(cls, d):
+    def zero_element(self, d):
         return np.zeros(d)
+
+
+CircularConvolutionAlgebra = _CircularConvolutionAlgebra()

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -41,7 +41,7 @@ class CircularConvolutionAlgebra(object):
         return v[-np.arange(len(v))]
 
     @classmethod
-    def get_binding_matrix(cls, v):
+    def get_binding_matrix(cls, v, swap_inputs=False):
         D = len(v)
         T = []
         for i in range(D):

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -7,10 +7,34 @@ from nengo_spa.networks.circularconvolution import CircularConvolution
 
 
 class CircularConvolutionAlgebra(AbstractAlgebra):
-    """Circular convolution algebra.
+    r"""Circular convolution algebra.
 
     Uses element-wise addition for superposition, circular convolution for
     binding with an approximate inverse.
+
+    The circular convolution :math:`c` of vectors :math:`a` and :math:`b`
+    is given by
+
+    .. math:: c[i] = \sum_j a[j] b[i - j]
+
+    where negative indices on :math:`b` wrap around to the end of the vector.
+
+    This computation can also be done in the Fourier domain,
+
+    .. math:: c = DFT^{-1} ( DFT(a) \odot DFT(b) )
+
+    where :math:`DFT` is the Discrete Fourier Transform operator, and
+    :math:`DFT^{-1}` is its inverse. This network uses this method.
+
+    Circular convolution as a binding operation is associative, commutative,
+    distributive.
+
+    More information on circular convolution as a binding operation can be
+    found in [plate2003]_.
+
+    .. [plate2003] Plate, Tony A. Holographic Reduced Representation:
+       Distributed Representation for Cognitive Structures. Stanford, CA: CSLI
+       Publications, 2003.
     """
 
     _instance = None
@@ -21,6 +45,22 @@ class CircularConvolutionAlgebra(AbstractAlgebra):
         return cls._instance
 
     def is_valid_dimensionality(self, d):
+        """Checks whether *d* is a valid vector dimensionality.
+
+        For circular convolution all positive numbers are valid
+        dimensionalities.
+
+        Parameters
+        ----------
+        d : int
+            Dimensionality
+
+        Returns
+        -------
+        bool
+            *True*, if *d* is a valid vector dimensionality for the use with
+            the algebra.
+        """
         return d > 0
 
     def make_unitary(self, v):
@@ -63,12 +103,63 @@ class CircularConvolutionAlgebra(AbstractAlgebra):
         return net, (net.input_a, net.input_b), net.output
 
     def absorbing_element(self, d):
+        r"""Return the standard absorbing element of dimensionality *d*.
+
+        An absorbing element will produce a scaled version of itself when bound
+        to another vector. The standard absorbing element is the absorbing
+        element with norm 1.
+
+        The absorbing element for circular convolution is the vector
+        :math:`(1, 1, \dots, 1)^{\top} / \sqrt{d}`.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Standard absorbing element.
+        """
         return np.ones(d) / np.sqrt(d)
 
     def identity_element(self, d):
+        r"""Return the identity element of dimensionality *d*.
+
+        The identity does not change the vector it is bound to.
+
+        The identity element for circular convolution is the vector
+        :math:`(1, 0, \dots, 0)^{\top}`.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Identity element.
+        """
         data = np.zeros(d)
         data[0] = 1.
         return data
 
     def zero_element(self, d):
+        """Return the zero element of dimensionality *d*.
+
+        The zero element produces itself when bound to a different vector.
+        For circular convolution this is the zero vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+
+        Returns
+        -------
+        (d,) ndarray
+            Zero element.
+        """
         return np.zeros(d)

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -13,6 +13,10 @@ class CircularConvolutionAlgebra(object):
     """
 
     @classmethod
+    def is_valid_dimensionality(cls, d):
+        return d > 0
+
+    @classmethod
     def make_unitary(cls, v):
         fft_val = np.fft.fft(v)
         fft_imag = fft_val.imag

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -1,5 +1,8 @@
+import nengo
 from nengo.utils.compat import range
 import numpy as np
+
+from nengo_spa.networks.circularconvolution import CircularConvolution
 
 
 class CircularConvolutionAlgebra(object):
@@ -40,6 +43,20 @@ class CircularConvolutionAlgebra(object):
         for i in range(D):
             T.append([v[(i - j) % D] for j in range(D)])
         return np.array(T)
+
+    @classmethod
+    def get_inversion_matrix(cls, d):
+        return np.eye(d)[-np.arange(d)]
+
+    @classmethod
+    def implement_superposition(cls, n_neurons_per_d, d, n):
+        node = nengo.Node(size_in=d)
+        return node, n * (node,), node
+
+    @classmethod
+    def implement_binding(cls, n_neurons_per_d, d, invert_a, invert_b):
+        net = CircularConvolution(n_neurons_per_d, d, invert_a, invert_b)
+        return net, (net.input_a, net.input_b), net.output
 
     @classmethod
     def absorbing_element(cls, d):

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -40,3 +40,17 @@ class CircularConvolutionAlgebra(object):
         for i in range(D):
             T.append([v[(i - j) % D] for j in range(D)])
         return np.array(T)
+
+    @classmethod
+    def absorbing_element(cls, d):
+        return np.ones(d) / np.sqrt(d)
+
+    @classmethod
+    def identity_element(cls, d):
+        data = np.zeros(d)
+        data[0] = 1.
+        return data
+
+    @classmethod
+    def zero_element(cls, d):
+        return np.zeros(d)

--- a/nengo_spa/algebras/cconv.py
+++ b/nengo_spa/algebras/cconv.py
@@ -24,7 +24,7 @@ class CircularConvolutionAlgebra(AbstractAlgebra):
     .. math:: c = DFT^{-1} ( DFT(a) \odot DFT(b) )
 
     where :math:`DFT` is the Discrete Fourier Transform operator, and
-    :math:`DFT^{-1}` is its inverse. This network uses this method.
+    :math:`DFT^{-1}` is its inverse.
 
     Circular convolution as a binding operation is associative, commutative,
     distributive.

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -47,6 +47,12 @@ def test_get_binding_matrix(algebra, rng):
     assert np.allclose(algebra.bind(a, b), np.dot(m, a))
 
 
+def test_get_inversion_matrix(algebra, rng):
+    a = SemanticPointer(50, rng).v
+    m = algebra.get_inversion_matrix(50)
+    assert np.allclose(algebra.invert(a), np.dot(m, a))
+
+
 def test_absorbing_element(algebra, rng):
     a = SemanticPointer(64, rng).v
     p = algebra.absorbing_element(64)

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from nengo_spa.pointer import SemanticPointer
+
+
+@pytest.mark.parametrize('d', [65, 100])
+def test_make_unitary(algebra, d, rng):
+    a = SemanticPointer(d, rng=rng).v
+    b = algebra.make_unitary(a)
+    for i in range(3):
+        assert np.allclose(1, np.linalg.norm(a))
+        assert np.allclose(1, np.linalg.norm(b))
+        a = algebra.bind(a, b)
+        assert np.allclose(1, np.linalg.norm(a))
+
+
+def test_superpose(algebra, rng):
+    a = SemanticPointer(10, rng).v
+    b = np.array(SemanticPointer(10, rng).v)
+    # Orthogonalize
+    b -= np.dot(a, b) * a
+    b /= np.linalg.norm(b)
+
+    r = algebra.superpose(a, b)
+    for v in (a, b):
+        assert np.dot(v, r / np.linalg.norm(r)) > 0.6
+
+
+@pytest.mark.parametrize('d', [64, 65])
+def test_binding_and_invert(algebra, d, rng):
+    a = SemanticPointer(d, rng=rng).v
+    b = SemanticPointer(d, rng=rng).v
+    bound = algebra.bind(a, b)
+    r = algebra.bind(bound, algebra.invert(b))
+    for v in (a, b):
+        assert np.dot(v, bound / np.linalg.norm(b)) < 0.7
+    assert np.dot(a, r / np.linalg.norm(r)) > 0.6
+
+
+def test_get_binding_matrix(algebra, rng):
+    a = SemanticPointer(50, rng).v
+    b = SemanticPointer(50, rng).v
+
+    m = algebra.get_binding_matrix(b)
+
+    assert np.allclose(algebra.bind(a, b), np.dot(m, a))

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -27,7 +27,7 @@ def test_superpose(algebra, rng):
         assert np.dot(v, r / np.linalg.norm(r)) > 0.6
 
 
-@pytest.mark.parametrize('d', [16, 25])
+@pytest.mark.parametrize('d', [25, 36])
 def test_binding_and_invert(algebra, d, rng):
     a = SemanticPointer(d, rng=rng).v
     b = SemanticPointer(d, rng=rng).v

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -45,3 +45,24 @@ def test_get_binding_matrix(algebra, rng):
     m = algebra.get_binding_matrix(b)
 
     assert np.allclose(algebra.bind(a, b), np.dot(m, a))
+
+
+def test_absorbing_element(algebra, rng):
+    a = SemanticPointer(64, rng).v
+    p = algebra.absorbing_element(64)
+    r = algebra.bind(a, p)
+    r /= np.linalg.norm(r)
+    assert np.allclose(p, r) or np.allclose(p, -r)
+
+
+def test_identity_element(algebra, rng):
+    a = SemanticPointer(64, rng).v
+    p = algebra.identity_element(64)
+    assert np.allclose(algebra.bind(a, p), a)
+
+
+def test_zero_element(algebra, rng):
+    a = SemanticPointer(64, rng).v
+    p = algebra.zero_element(64)
+    assert np.all(p == 0.)
+    assert np.allclose(algebra.bind(a, p), 0.)

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -38,6 +38,13 @@ def test_binding_and_invert(algebra, d, rng):
     assert np.dot(a, r / np.linalg.norm(r)) > 0.6
 
 
+def test_dimensionality_mismatch_exception(algebra):
+    with pytest.raises(ValueError):
+        algebra.bind(np.ones(16), np.ones(25))
+    with pytest.raises(ValueError):
+        algebra.superpose(np.ones(16), np.ones(25))
+
+
 def test_get_binding_matrix(algebra, rng):
     a = SemanticPointer(16, rng).v
     b = SemanticPointer(16, rng).v

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -4,7 +4,7 @@ import pytest
 from nengo_spa.pointer import SemanticPointer
 
 
-@pytest.mark.parametrize('d', [65, 100])
+@pytest.mark.parametrize('d', [16, 25])
 def test_make_unitary(algebra, d, rng):
     a = SemanticPointer(d, rng=rng).v
     b = algebra.make_unitary(a)
@@ -16,8 +16,8 @@ def test_make_unitary(algebra, d, rng):
 
 
 def test_superpose(algebra, rng):
-    a = SemanticPointer(10, rng).v
-    b = np.array(SemanticPointer(10, rng).v)
+    a = SemanticPointer(16, rng).v
+    b = np.array(SemanticPointer(16, rng).v)
     # Orthogonalize
     b -= np.dot(a, b) * a
     b /= np.linalg.norm(b)
@@ -27,7 +27,7 @@ def test_superpose(algebra, rng):
         assert np.dot(v, r / np.linalg.norm(r)) > 0.6
 
 
-@pytest.mark.parametrize('d', [64, 65])
+@pytest.mark.parametrize('d', [16, 25])
 def test_binding_and_invert(algebra, d, rng):
     a = SemanticPointer(d, rng=rng).v
     b = SemanticPointer(d, rng=rng).v
@@ -39,8 +39,8 @@ def test_binding_and_invert(algebra, d, rng):
 
 
 def test_get_binding_matrix(algebra, rng):
-    a = SemanticPointer(50, rng).v
-    b = SemanticPointer(50, rng).v
+    a = SemanticPointer(16, rng).v
+    b = SemanticPointer(16, rng).v
 
     m = algebra.get_binding_matrix(b)
 
@@ -48,27 +48,30 @@ def test_get_binding_matrix(algebra, rng):
 
 
 def test_get_inversion_matrix(algebra, rng):
-    a = SemanticPointer(50, rng).v
-    m = algebra.get_inversion_matrix(50)
+    a = SemanticPointer(16, rng).v
+    m = algebra.get_inversion_matrix(16)
     assert np.allclose(algebra.invert(a), np.dot(m, a))
 
 
 def test_absorbing_element(algebra, rng):
-    a = SemanticPointer(64, rng).v
-    p = algebra.absorbing_element(64)
-    r = algebra.bind(a, p)
-    r /= np.linalg.norm(r)
-    assert np.allclose(p, r) or np.allclose(p, -r)
+    a = SemanticPointer(16, rng).v
+    try:
+        p = algebra.absorbing_element(16)
+        r = algebra.bind(a, p)
+        r /= np.linalg.norm(r)
+        assert np.allclose(p, r) or np.allclose(p, -r)
+    except NotImplementedError:
+        pass
 
 
 def test_identity_element(algebra, rng):
-    a = SemanticPointer(64, rng).v
-    p = algebra.identity_element(64)
+    a = SemanticPointer(16, rng).v
+    p = algebra.identity_element(16)
     assert np.allclose(algebra.bind(a, p), a)
 
 
 def test_zero_element(algebra, rng):
-    a = SemanticPointer(64, rng).v
-    p = algebra.zero_element(64)
+    a = SemanticPointer(16, rng).v
+    p = algebra.zero_element(16)
     assert np.all(p == 0.)
     assert np.allclose(algebra.bind(a, p), 0.)

--- a/nengo_spa/algebras/tests/test_cconv.py
+++ b/nengo_spa/algebras/tests/test_cconv.py
@@ -1,0 +1,5 @@
+from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
+
+
+def test_is_singleton():
+    assert CircularConvolutionAlgebra() is CircularConvolutionAlgebra()

--- a/nengo_spa/algebras/tests/test_vtb.py
+++ b/nengo_spa/algebras/tests/test_vtb.py
@@ -8,6 +8,16 @@ def test_is_singleton():
     assert VtbAlgebra() is VtbAlgebra()
 
 
+def test_is_valid_dimensionality():
+    assert not VtbAlgebra().is_valid_dimensionality(-1)
+    assert not VtbAlgebra().is_valid_dimensionality(0)
+    assert not VtbAlgebra().is_valid_dimensionality(15)
+    assert not VtbAlgebra().is_valid_dimensionality(24)
+    assert VtbAlgebra().is_valid_dimensionality(1)
+    assert VtbAlgebra().is_valid_dimensionality(16)
+    assert VtbAlgebra().is_valid_dimensionality(25)
+
+
 def test_get_swapping_matrix(rng):
     a = SemanticPointer(64, rng, algebra=VtbAlgebra()).v
     b = SemanticPointer(64, rng, algebra=VtbAlgebra()).v

--- a/nengo_spa/algebras/tests/test_vtb.py
+++ b/nengo_spa/algebras/tests/test_vtb.py
@@ -4,9 +4,14 @@ from nengo_spa.algebras.vtb import VtbAlgebra
 from nengo_spa.pointer import SemanticPointer
 
 
-def test_get_swapping_matrix(rng):
-    a = SemanticPointer(64, rng, algebra=VtbAlgebra).v
-    b = SemanticPointer(64, rng, algebra=VtbAlgebra).v
+def test_is_singleton():
+    assert VtbAlgebra() is VtbAlgebra()
 
-    m = VtbAlgebra.get_swapping_matrix(64)
-    assert np.allclose(VtbAlgebra.bind(a, b), np.dot(m, VtbAlgebra.bind(b, a)))
+
+def test_get_swapping_matrix(rng):
+    a = SemanticPointer(64, rng, algebra=VtbAlgebra()).v
+    b = SemanticPointer(64, rng, algebra=VtbAlgebra()).v
+
+    m = VtbAlgebra().get_swapping_matrix(64)
+    assert np.allclose(
+        VtbAlgebra().bind(a, b), np.dot(m, VtbAlgebra().bind(b, a)))

--- a/nengo_spa/algebras/tests/test_vtb.py
+++ b/nengo_spa/algebras/tests/test_vtb.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from nengo_spa.algebras.vtb import VtbAlgebra
+from nengo_spa.pointer import SemanticPointer
+
+
+def test_get_swapping_matrix(rng):
+    a = SemanticPointer(64, rng, algebra=VtbAlgebra).v
+    b = SemanticPointer(64, rng, algebra=VtbAlgebra).v
+
+    m = VtbAlgebra.get_swapping_matrix(64)
+    assert np.allclose(VtbAlgebra.bind(a, b), np.dot(m, VtbAlgebra.bind(b, a)))

--- a/nengo_spa/algebras/vtb.py
+++ b/nengo_spa/algebras/vtb.py
@@ -58,10 +58,22 @@ class VtbAlgebra(object):
         return v.reshape((sub_d, sub_d)).T.flatten()
 
     @classmethod
-    def get_binding_matrix(cls, v):
+    def get_binding_matrix(cls, v, swap_inputs=False):
         sub_d = cls._get_sub_d(len(v))
-        return np.sqrt(sub_d) * np.kron(
+        m = np.sqrt(sub_d) * np.kron(
             np.eye(sub_d), v.reshape((sub_d, sub_d)))
+        if swap_inputs:
+            m = np.dot(cls.get_swapping_matrix(len(v)), m)
+        return m
+
+    @classmethod
+    def get_swapping_matrix(cls, d):
+        sub_d = cls._get_sub_d(d)
+        m = np.zeros((d, d))
+        for i in range(d):
+            j = i // sub_d + sub_d * (i % sub_d)
+            m[i, j] = 1.
+        return m
 
     @classmethod
     def get_inversion_matrix(cls, d):

--- a/nengo_spa/algebras/vtb.py
+++ b/nengo_spa/algebras/vtb.py
@@ -1,9 +1,8 @@
 import nengo
-from nengo.dists import CosineSimilarity
 from nengo.utils.compat import range
 import numpy as np
 
-from nengo_spa.networks.matrix_multiplication import MatrixMult
+from nengo_spa.networks.vtb import VTB
 
 
 class VtbAlgebra(object):
@@ -91,51 +90,7 @@ class VtbAlgebra(object):
 
     @classmethod
     def implement_binding(cls, n_neurons_per_d, d, unbind_left, unbind_right):
-        sub_d = cls._get_sub_d(d)
-        shape_left = (sub_d, sub_d)
-        shape_right = (sub_d, 1)
-
-        with nengo.Network() as net:
-            net.input_left = nengo.Node(size_in=d)
-            net.input_right = nengo.Node(size_in=d)
-            net.output = nengo.Node(size_in=d)
-
-            net.mat = nengo.Node(size_in=d)
-            net.vec = nengo.Node(size_in=d)
-
-            if unbind_left and unbind_right:
-                raise ValueError("Cannot unbind both sides at the same time.")
-            elif unbind_left:
-                nengo.Connection(
-                    net.input_left, net.mat,
-                    transform=cls.get_inversion_matrix(d), synapse=None)
-                nengo.Connection(
-                    net.input_right, net.vec,
-                    transform=cls.get_swapping_matrix(d), synapse=None)
-            else:
-                nengo.Connection(net.input_left, net.vec, synapse=None)
-                if unbind_right:
-                    tr = cls.get_inversion_matrix(d)
-                else:
-                    tr = 1.
-                nengo.Connection(
-                    net.input_right, net.mat, transform=tr, synapse=None)
-
-            with nengo.Config(nengo.Ensemble) as cfg:
-                cfg[nengo.Ensemble].intercepts = CosineSimilarity(d+2)
-                cfg[nengo.Ensemble].eval_points = CosineSimilarity(d+2)
-                net.matmuls = [
-                    MatrixMult(n_neurons_per_d, shape_left, shape_right)
-                    for i in range(sub_d)]
-
-            for i in range(sub_d):
-                mm = net.matmuls[i]
-                sl = slice(i * sub_d, (i + 1) * sub_d)
-                nengo.Connection(net.mat, mm.input_left, synapse=None)
-                nengo.Connection(net.vec[sl], mm.input_right, synapse=None)
-                nengo.Connection(
-                    mm.output, net.output[sl], transform=np.sqrt(sub_d),
-                    synapse=None)
+        net = VTB(n_neurons_per_d, d, unbind_left, unbind_right)
         return net, (net.input_left, net.input_right), net.output
 
     @classmethod

--- a/nengo_spa/algebras/vtb.py
+++ b/nengo_spa/algebras/vtb.py
@@ -1,0 +1,91 @@
+from nengo.utils.compat import range
+import numpy as np
+
+
+class VtbAlgebra(object):
+    """Circular convolution algebra.
+
+    Uses element-wise addition for superposition, circular convolution for
+    binding with an approximate inverse.
+    """
+
+    @classmethod
+    def is_valid_dimensionality(cls, d):
+        if d < 1:
+            return False
+        sub_d = np.sqrt(d)
+        return sub_d * sub_d == d
+
+    @classmethod
+    def _get_sub_d(cls, d):
+        sub_d = int(np.sqrt(d))
+        if sub_d * sub_d != d:
+            raise ValueError("Vector dimensionality must be a square number.")
+        return sub_d
+
+    @classmethod
+    def make_unitary(cls, v):
+        sub_d = cls._get_sub_d(len(v))
+        m = np.array(v.reshape((sub_d, sub_d)))
+        for i in range(1, sub_d):
+            y = -np.dot(m[:i, i:], m[i, i:])
+            A = m[:i, :i]
+            m[i, :i] = np.linalg.solve(A, y)
+        m /= np.linalg.norm(m, axis=1)[:, None]
+        m /= np.sqrt(sub_d)
+        return m.flatten()
+
+    @classmethod
+    def superpose(cls, a, b):
+        return a + b
+
+    @classmethod
+    def bind(cls, a, b):
+        d = len(a)
+        if len(b) != d:
+            raise ValueError("Inputs must have same length.")
+        sub_d = cls._get_sub_d(d)
+        m = cls.get_binding_matrix(b)
+        return np.dot(m, a)
+
+    @classmethod
+    def invert(cls, v):
+        sub_d = cls._get_sub_d(len(v))
+        return v.reshape((sub_d, sub_d)).T.flatten()
+
+    @classmethod
+    def get_binding_matrix(cls, v):
+        sub_d = cls._get_sub_d(len(v))
+        return np.sqrt(sub_d) * np.kron(
+            np.eye(sub_d), v.reshape((sub_d, sub_d)))
+
+    @classmethod
+    def get_inversion_matrix(cls, d):
+        sub_d = cls._get_sub_d(d)
+        m = np.zeros((d, d))
+        for i in range(d):
+            j = sub_d * i
+            m[j % d + j // d, i] = 1.
+        return m
+
+    @classmethod
+    def implement_superposition(cls, n_neurons_per_d, d, n):
+        raise NotImplementedError()
+
+    @classmethod
+    def implement_binding(cls, n_neurons_per_d, d, invert_a, invert_b):
+        raise NotImplementedError()
+
+    @classmethod
+    def absorbing_element(cls, d):
+        raise NotImplementedError(
+            "VtbAlgebra does not have any absorbing elements.")
+
+    @classmethod
+    def identity_element(cls, d):
+        sub_d = cls._get_sub_d(d)
+        return (np.eye(sub_d) / d**0.25).flatten()
+
+    @classmethod
+    def zero_element(cls, d):
+        return np.zeros(d)

--- a/nengo_spa/algebras/vtb.py
+++ b/nengo_spa/algebras/vtb.py
@@ -6,12 +6,19 @@ from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.networks.vtb import VTB
 
 
-class _VtbAlgebra(AbstractAlgebra):
+class VtbAlgebra(AbstractAlgebra):
     """Circular convolution algebra.
 
     Uses element-wise addition for superposition, circular convolution for
     binding with an approximate inverse.
     """
+
+    _instance = None
+
+    def __new__(cls):
+        if type(cls._instance) is not cls:
+            cls._instance = super(VtbAlgebra, cls).__new__(cls)
+        return cls._instance
 
     def is_valid_dimensionality(self, d):
         if d < 1:
@@ -92,6 +99,3 @@ class _VtbAlgebra(AbstractAlgebra):
 
     def zero_element(self, d):
         return np.zeros(d)
-
-
-VtbAlgebra = _VtbAlgebra()

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -82,18 +82,20 @@ class DynamicNode(Node):
         type_ = infer_types(self, other)
         if type_ == TScalar:
             mul = ProductRealization()
+            input_left, input_right = mul.input_a, mul.input_b
         elif self.type == TScalar or other.type == TScalar:
             raise NotImplementedError(
                 "Dynamic scaling of semantic pointer not implemented.")
         else:
             mul = BindRealization(self.type.vocab)
+            input_left, input_right = mul.input_left, mul.input_right
 
         if swap_inputs:
             a, b = other, self
         else:
             a, b = self, other
-        a.connect_to(mul.input_a)
-        b.connect_to(mul.input_b)
+        a.connect_to(input_left)
+        b.connect_to(input_right)
         return ModuleOutput(mul.output, type_)
 
     @binary_node_op

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -60,7 +60,7 @@ class DynamicNode(Node):
     def __rsub__(self, other):
         return (-self) + other
 
-    def _mul_with_fixed(self, other):
+    def _mul_with_fixed(self, other, swap_inputs=False):
         infer_types(self, other)
         if other.type == TScalar:
             tr = other.value
@@ -72,7 +72,8 @@ class DynamicNode(Node):
             if self.type == TScalar:
                 tr = other.evaluate().v
             else:
-                tr = other.evaluate().get_binding_matrix()
+                tr = other.evaluate().get_binding_matrix(
+                    swap_inputs=swap_inputs)
         else:
             raise AssertionError("Unexpected node type in multiply.")
         return Transformed(self, tr, self.type)
@@ -105,7 +106,7 @@ class DynamicNode(Node):
     @binary_node_op
     def __rmul__(self, other):
         if isinstance(other, Symbol):
-            return self._mul_with_fixed(other)
+            return self._mul_with_fixed(other, swap_inputs=True)
         else:
             return self._mul_with_dynamic(other, swap_inputs=True)
 

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -71,7 +71,7 @@ class DynamicNode(Node):
             if self.type == TScalar:
                 tr = other.evaluate().v
             else:
-                tr = other.evaluate().get_convolution_matrix()
+                tr = other.evaluate().get_binding_matrix()
         else:
             raise AssertionError("Unexpected node type in multiply.")
         return Transformed(self, tr, self.type)

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -14,8 +14,8 @@ from nengo_spa.testing import sp_close
 
 @pytest.mark.parametrize('op', ['-', '~'])
 @pytest.mark.parametrize('suffix', ['', '.output'])
-def test_unary_operation_on_module(Simulator, op, suffix, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_unary_operation_on_module(Simulator, algebra, op, suffix, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A')
 
     with spa.Network() as model:
@@ -31,8 +31,8 @@ def test_unary_operation_on_module(Simulator, op, suffix, rng):
 
 @pytest.mark.parametrize('op', ['+', '-', '*'])
 @pytest.mark.parametrize('suffix', ['', '.output'])
-def test_binary_operation_on_modules(Simulator, op, suffix, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_binary_operation_on_modules(Simulator, algebra, op, suffix, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -52,8 +52,8 @@ def test_binary_operation_on_modules(Simulator, op, suffix, rng):
 @pytest.mark.parametrize('op', ['+', '-', '*'])
 @pytest.mark.parametrize('order', ['AB', 'BA'])
 def test_binary_operation_on_modules_with_pointer_symbol(
-        Simulator, op, order, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+        Simulator, algebra, op, order, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -77,8 +77,8 @@ def test_binary_operation_on_modules_with_pointer_symbol(
 @pytest.mark.parametrize('op', ['+', '-', '*'])
 @pytest.mark.parametrize('order', ['AB', 'BA'])
 def test_binary_operation_on_modules_with_fixed_pointer(
-        Simulator, op, order, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+        Simulator, algebra, op, order, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
     b = SemanticPointer(vocab['B'].v)  # noqa: F841
 
@@ -100,8 +100,8 @@ def test_binary_operation_on_modules_with_fixed_pointer(
         skip=0.3)
 
 
-def test_complex_rule(Simulator, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_complex_rule(Simulator, algebra, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B; C; D')
 
     with spa.Network() as model:
@@ -121,8 +121,8 @@ def test_complex_rule(Simulator, rng):
         skip=0.3, normalized=True)
 
 
-def test_transformed(Simulator, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_transformed(Simulator, algebra, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -138,8 +138,8 @@ def test_transformed(Simulator, rng):
         normalized=True)
 
 
-def test_transformed_and_pointer_symbol(Simulator, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_transformed_and_pointer_symbol(Simulator, algebra, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -155,8 +155,8 @@ def test_transformed_and_pointer_symbol(Simulator, rng):
         normalized=True)
 
 
-def test_transformed_and_network(Simulator, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_transformed_and_network(Simulator, algebra, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B.unitary()')
 
     with spa.Network() as model:
@@ -173,8 +173,8 @@ def test_transformed_and_network(Simulator, rng):
         normalized=True)
 
 
-def test_transformed_and_transformed(Simulator, rng):
-    vocab = spa.Vocabulary(64, rng=rng)
+def test_transformed_and_transformed(Simulator, algebra, rng):
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B.unitary(); C')
 
     with spa.Network() as model:

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -12,6 +12,27 @@ from nengo_spa.pointer import SemanticPointer
 from nengo_spa.testing import assert_sp_close
 
 
+def test_scalar_addition(Simulator):
+    with spa.Network() as model:
+        a = spa.Scalar()
+        b = spa.Scalar()
+
+        0.3 >> a
+        0.2 >> b
+        n1 = (a + b).construct()
+        n2 = nengo.Node(size_in=1)
+        (a + b).connect_to(n2)
+
+        p1 = nengo.Probe(n1, synapse=0.03)
+        p2 = nengo.Probe(n2, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.3)
+
+    assert np.all(np.abs(sim.data[p1][sim.trange() > 0.2] - 0.5) < 0.1)
+    assert np.all(np.abs(sim.data[p2][sim.trange() > 0.2] - 0.5) < 0.1)
+
+
 @pytest.mark.parametrize('op', ['-', '~'])
 @pytest.mark.parametrize('suffix', ['', '.output'])
 def test_unary_operation_on_module(Simulator, algebra, op, suffix, rng):

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -9,7 +9,7 @@ import nengo_spa as spa
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.pointer import SemanticPointer
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 @pytest.mark.parametrize('op', ['-', '~'])
@@ -26,7 +26,7 @@ def test_unary_operation_on_module(Simulator, algebra, op, suffix, rng):
     with Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(sim.trange(), sim.data[p], vocab.parse(op + 'A'), skip=0.2)
+    assert_sp_close(sim.trange(), sim.data[p], vocab.parse(op + 'A'), skip=0.2)
 
 
 @pytest.mark.parametrize('op', ['+', '-', '*'])
@@ -44,7 +44,7 @@ def test_binary_operation_on_modules(Simulator, algebra, op, suffix, rng):
     with Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A' + op + 'B'), skip=0.2,
         atol=0.3)
 
@@ -69,7 +69,7 @@ def test_binary_operation_on_modules_with_pointer_symbol(
     with Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
         skip=0.2)
 
@@ -95,7 +95,7 @@ def test_binary_operation_on_modules_with_fixed_pointer(
     with Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
         skip=0.2, atol=0.3)
 
@@ -115,7 +115,7 @@ def test_complex_rule(Simulator, algebra, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p],
         vocab.parse('(0.5 * C * A + 0.5 * D) * (0.5 * B + 0.5 * A)'),
         skip=0.2, normalized=True)
@@ -133,7 +133,7 @@ def test_transformed(Simulator, algebra, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('B*A'), skip=0.2,
         normalized=True)
 
@@ -150,7 +150,7 @@ def test_transformed_and_pointer_symbol(Simulator, algebra, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.2,
         normalized=True)
 
@@ -168,7 +168,7 @@ def test_transformed_and_network(Simulator, algebra, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A * ~B * B'), skip=0.2,
         normalized=True)
 
@@ -186,7 +186,7 @@ def test_transformed_and_transformed(Simulator, algebra, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.3)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('(B * A) * (~B * C)'), skip=0.2,
         normalized=True, atol=0.3)
 
@@ -290,4 +290,4 @@ def test_dynamic_translate(Simulator, rng):
     with nengo.Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(sim.trange(), sim.data[p], v2['A'], skip=0.3, atol=0.2)
+    assert_sp_close(sim.trange(), sim.data[p], v2['A'], skip=0.3, atol=0.2)

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -15,7 +15,7 @@ from nengo_spa.testing import sp_close
 @pytest.mark.parametrize('op', ['-', '~'])
 @pytest.mark.parametrize('suffix', ['', '.output'])
 def test_unary_operation_on_module(Simulator, algebra, op, suffix, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A')
 
     with spa.Network() as model:
@@ -24,15 +24,15 @@ def test_unary_operation_on_module(Simulator, algebra, op, suffix, rng):
         p = nengo.Probe(x.construct(), synapse=0.03)
 
     with Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
-    assert sp_close(sim.trange(), sim.data[p], vocab.parse(op + 'A'), skip=0.3)
+    assert sp_close(sim.trange(), sim.data[p], vocab.parse(op + 'A'), skip=0.2)
 
 
 @pytest.mark.parametrize('op', ['+', '-', '*'])
 @pytest.mark.parametrize('suffix', ['', '.output'])
 def test_binary_operation_on_modules(Simulator, algebra, op, suffix, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -53,7 +53,7 @@ def test_binary_operation_on_modules(Simulator, algebra, op, suffix, rng):
 @pytest.mark.parametrize('order', ['AB', 'BA'])
 def test_binary_operation_on_modules_with_pointer_symbol(
         Simulator, algebra, op, order, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -67,18 +67,18 @@ def test_binary_operation_on_modules_with_pointer_symbol(
         p = nengo.Probe(x.construct(), synapse=0.03)
 
     with Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
-        skip=0.3)
+        skip=0.2)
 
 
 @pytest.mark.parametrize('op', ['+', '-', '*'])
 @pytest.mark.parametrize('order', ['AB', 'BA'])
 def test_binary_operation_on_modules_with_fixed_pointer(
         Simulator, algebra, op, order, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
     b = SemanticPointer(vocab['B'].v)  # noqa: F841
 
@@ -93,15 +93,15 @@ def test_binary_operation_on_modules_with_fixed_pointer(
         p = nengo.Probe(x.construct(), synapse=0.03)
 
     with Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
-        skip=0.3, atol=0.3)
+        skip=0.2, atol=0.3)
 
 
 def test_complex_rule(Simulator, algebra, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B; C; D')
 
     with spa.Network() as model:
@@ -113,16 +113,16 @@ def test_complex_rule(Simulator, algebra, rng):
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
         sim.trange(), sim.data[p],
         vocab.parse('(0.5 * C * A + 0.5 * D) * (0.5 * B + 0.5 * A)'),
-        skip=0.3, normalized=True)
+        skip=0.2, normalized=True)
 
 
 def test_transformed(Simulator, algebra, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -131,15 +131,15 @@ def test_transformed(Simulator, algebra, rng):
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('B*A'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('B*A'), skip=0.2,
         normalized=True)
 
 
 def test_transformed_and_pointer_symbol(Simulator, algebra, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network() as model:
@@ -148,15 +148,15 @@ def test_transformed_and_pointer_symbol(Simulator, algebra, rng):
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.2,
         normalized=True)
 
 
 def test_transformed_and_network(Simulator, algebra, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B.unitary()')
 
     with spa.Network() as model:
@@ -166,15 +166,15 @@ def test_transformed_and_network(Simulator, algebra, rng):
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('A * ~B * B'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('A * ~B * B'), skip=0.2,
         normalized=True)
 
 
 def test_transformed_and_transformed(Simulator, algebra, rng):
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B.unitary(); C')
 
     with spa.Network() as model:
@@ -184,11 +184,11 @@ def test_transformed_and_transformed(Simulator, algebra, rng):
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('(B * A) * (~B * C)'), skip=0.3,
-        normalized=True)
+        sim.trange(), sim.data[p], vocab.parse('(B * A) * (~B * C)'), skip=0.2,
+        normalized=True, atol=0.3)
 
 
 def test_pointer_symbol_with_dynamic_scalar(Simulator, rng):

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -42,10 +42,10 @@ def test_binary_operation_on_modules(Simulator, algebra, op, suffix, rng):
         p = nengo.Probe(x.construct(), synapse=0.03)
 
     with Simulator(model) as sim:
-        sim.run(0.5)
+        sim.run(0.3)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('A' + op + 'B'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('A' + op + 'B'), skip=0.2,
         atol=0.3)
 
 
@@ -97,7 +97,7 @@ def test_binary_operation_on_modules_with_fixed_pointer(
 
     assert sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
-        skip=0.3)
+        skip=0.3, atol=0.3)
 
 
 def test_complex_rule(Simulator, algebra, rng):
@@ -144,14 +144,14 @@ def test_transformed_and_pointer_symbol(Simulator, algebra, rng):
 
     with spa.Network() as model:
         a = spa.Transcode('A', output_vocab=vocab)
-        x = PointerSymbol('~B') * (PointerSymbol('B') * a)
+        x = (a * PointerSymbol('B')) * PointerSymbol('~B')
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
         sim.run(0.5)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('~B * B * A'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.3,
         normalized=True)
 
 
@@ -162,14 +162,14 @@ def test_transformed_and_network(Simulator, algebra, rng):
     with spa.Network() as model:
         a = spa.Transcode('A', output_vocab=vocab)
         b = spa.Transcode('B', output_vocab=vocab)
-        x = b * (PointerSymbol('~B') * a)
+        x = (a * PointerSymbol('~B')) * b
         p = nengo.Probe(x.construct(), synapse=0.3)
 
     with nengo.Simulator(model) as sim:
         sim.run(0.5)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('B * ~B * A'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('A * ~B * B'), skip=0.3,
         normalized=True)
 
 
@@ -187,7 +187,7 @@ def test_transformed_and_transformed(Simulator, algebra, rng):
         sim.run(0.5)
 
     assert sp_close(
-        sim.trange(), sim.data[p], vocab.parse('B * A * ~B * C'), skip=0.3,
+        sim.trange(), sim.data[p], vocab.parse('(B * A) * (~B * C)'), skip=0.3,
         normalized=True)
 
 

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -21,7 +21,7 @@ class TestConfig(object):
     module modify these values accordingly.
     """
 
-    algebras = [CircularConvolutionAlgebra, VtbAlgebra]
+    algebras = [CircularConvolutionAlgebra(), VtbAlgebra()]
 
 
 def pytest_generate_tests(metafunc):

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -4,6 +4,7 @@ from nengo.conftest import (  # pylint: disable=unused-import
 import pytest
 
 from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
+from nengo_spa.algebras.vtb import VtbAlgebra
 
 
 class TestConfig(object):
@@ -17,7 +18,7 @@ class TestConfig(object):
     module modify these values accordingly.
     """
 
-    algebras = [CircularConvolutionAlgebra]
+    algebras = [CircularConvolutionAlgebra, VtbAlgebra]
 
 
 def pytest_generate_tests(metafunc):

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -22,9 +22,5 @@ class TestConfig(object):
 
 
 def pytest_generate_tests(metafunc):
-    marks = [
-        getattr(pytest.mark, m.name)(*m.args, **m.kwargs)
-        for m in getattr(metafunc.function, 'pytestmark', [])]
-
     if 'algebra' in metafunc.funcargnames:
         metafunc.parametrize('algebra', [a for a in TestConfig.algebras])

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -1,3 +1,29 @@
 from nengo.conftest import (  # pylint: disable=unused-import
     pytest_configure, pytest_runtest_setup, RefSimulator, Simulator, plt, seed,
     rng)
+import pytest
+
+from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
+
+
+class TestConfig(object):
+    """Parameters affecting all Nengo SPA testes.
+
+    These are essentially global variables used by py.test to modify aspects
+    of the Nengo SPA tests. We collect them in this class to provide a mini
+    namespace and to avoid using the ``global`` keyword.
+
+    The values below are defaults. The functions in the remainder of this
+    module modify these values accordingly.
+    """
+
+    algebras = [CircularConvolutionAlgebra]
+
+
+def pytest_generate_tests(metafunc):
+    marks = [
+        getattr(pytest.mark, m.name)(*m.args, **m.kwargs)
+        for m in getattr(metafunc.function, 'pytestmark', [])]
+
+    if 'algebra' in metafunc.funcargnames:
+        metafunc.parametrize('algebra', [a for a in TestConfig.algebras])

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -1,6 +1,9 @@
+import os.path
+
 from nengo.conftest import (  # pylint: disable=unused-import
-    pytest_configure, pytest_runtest_setup, RefSimulator, Simulator, plt, seed,
-    rng)
+    parametrize_function_name, pytest_configure, pytest_runtest_setup,
+    recorder_dirname, RefSimulator, Simulator, seed, rng)
+from nengo.utils.testing import Plotter
 import pytest
 
 from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
@@ -24,3 +27,32 @@ class TestConfig(object):
 def pytest_generate_tests(metafunc):
     if 'algebra' in metafunc.funcargnames:
         metafunc.parametrize('algebra', [a for a in TestConfig.algebras])
+
+
+def recorder_dirname_with_algebra(request, name):
+    dirname = recorder_dirname(request, name)
+    if 'algebra' in request.funcargnames:
+        algebra = request.getfixturevalue('algebra')
+        dirname = os.path.join(dirname, algebra.__name__)
+    return dirname
+
+
+@pytest.fixture
+def plt(request):
+    """A pyplot-compatible plotting interface.
+
+    Please use this if your test creates plots.
+
+    This will keep saved plots organized in a simulator-specific folder,
+    with an automatically generated name. savefig() and close() will
+    automatically be called when the test function completes.
+
+    If you need to override the default filename, set `plt.saveas` to
+    the desired filename.
+    """
+    dirname = recorder_dirname_with_algebra(request, 'plots')
+    plotter = Plotter(
+        dirname, request.module.__name__,
+        parametrize_function_name(request, request.function.__name__))
+    request.addfinalizer(lambda: plotter.__exit__(None, None, None))
+    return plotter.__enter__()

--- a/nengo_spa/modules/__init__.py
+++ b/nengo_spa/modules/__init__.py
@@ -26,6 +26,7 @@ from .compare import Compare
 from .product import Product
 from .scalar import Scalar
 from .state import State
+from .superposition import Superposition
 from .thalamus import Thalamus
 from .transcode import Transcode
 
@@ -37,6 +38,7 @@ def _register_default_modules():
     _dynamic.ProductRealization = Product
     _dynamic.ScalarRealization = Scalar
     _dynamic.StateRealization = State
+    _dynamic.SuperpositionRealization = Superposition
     _dynamic.ThalamusRealization = Thalamus
 
 

--- a/nengo_spa/modules/bind.py
+++ b/nengo_spa/modules/bind.py
@@ -15,22 +15,19 @@ class Bind(Network):
         the default vocabulary of that dimensionality will be used.
     neurons_per_dimension : int, optional (Default: 200)
         Number of neurons to use in each dimension.
-    invert_a : bool, optional
-        Whether to reverse the order of elements in first input.
-    invert_b : bool, optional
-        Whether to reverse the order of elements in the second input.
-        Flipping exactly one input will make the network perform circular
-        correlation instead of circular convolution which can be treated as an
-        approximate inverse to circular convolution.
+    unbind_left : bool, optional
+        Whether to unbind the left input.
+    unbind_right : bool, optional
+        Whether to unbind the right input.
     kwargs : dict
         Keyword arguments passed through to `nengo_spa.Network`.
 
     Attributes
     ----------
-    input_a : nengo.Node
-        First input vector.
-    input_b : nengo.Node
-        Second input vector.
+    input_left : nengo.Node
+        Left input vector.
+    input_right : nengo.Node
+        Right input vector.
     output : nengo.Node
         Output.
     """
@@ -38,29 +35,29 @@ class Bind(Network):
     vocab = VocabularyOrDimParam('vocab', default=None, readonly=True)
     neurons_per_dimension = IntParam(
         'neurons_per_dimension', default=200, low=1, readonly=True)
-    invert_a = BoolParam('invert_a', default=False, readonly=True)
-    invert_b = BoolParam('invert_b', default=False, readonly=True)
+    unbind_left = BoolParam('unbind_left', default=False, readonly=True)
+    unbind_right = BoolParam('unbind_right', default=False, readonly=True)
 
     def __init__(self, vocab=Default, neurons_per_dimension=Default,
-                 invert_a=Default, invert_b=Default, **kwargs):
+                 unbind_left=Default, unbind_right=Default, **kwargs):
         kwargs.setdefault('label', "Bind")
         super(Bind, self).__init__(**kwargs)
 
         self.vocab = vocab
         self.neurons_per_dimension = neurons_per_dimension
-        self.invert_a = invert_a
-        self.invert_b = invert_b
+        self.unbind_left = unbind_left
+        self.unbind_right = unbind_right
 
         with self:
             self.binding_net, inputs, output = (
                 self.vocab.algebra.implement_binding(
                     self.neurons_per_dimension, self.vocab.dimensions,
-                    self.invert_a, self.invert_b))
+                    self.unbind_left, self.unbind_right))
 
-        self.input_a = inputs[0]
-        self.input_b = inputs[1]
+        self.input_left = inputs[0]
+        self.input_right = inputs[1]
         self.output = output
 
-        self.declare_input(self.input_a, self.vocab)
-        self.declare_input(self.input_b, self.vocab)
+        self.declare_input(self.input_left, self.vocab)
+        self.declare_input(self.input_right, self.vocab)
         self.declare_output(self.output, self.vocab)

--- a/nengo_spa/modules/bind.py
+++ b/nengo_spa/modules/bind.py
@@ -8,17 +8,13 @@ from nengo_spa.vocab import VocabularyOrDimParam
 class Bind(Network):
     """Network for binding together two inputs.
 
-    Binding is done with circular convolution. For more details on how
-    this is computed, see the underlying `.CircularConvolution`
-    network.
-
     Parameters
     ----------
     vocab : Vocabulary or int
         The vocabulary to use to interpret the vector. If an integer is given,
         the default vocabulary of that dimensionality will be used.
     neurons_per_dimension : int, optional (Default: 200)
-        Number of neurons to use in each product computation.
+        Number of neurons to use in each dimension.
     invert_a : bool, optional
         Whether to reverse the order of elements in first input.
     invert_b : bool, optional
@@ -56,13 +52,14 @@ class Bind(Network):
         self.invert_b = invert_b
 
         with self:
-            self.cc = nengo_spa.networks.CircularConvolution(
-                self.neurons_per_dimension, self.vocab.dimensions,
-                self.invert_a, self.invert_b)
+            self.binding_net, inputs, output = (
+                self.vocab.algebra.implement_binding(
+                    self.neurons_per_dimension, self.vocab.dimensions,
+                    self.invert_a, self.invert_b))
 
-        self.input_a = self.cc.input_a
-        self.input_b = self.cc.input_b
-        self.output = self.cc.output
+        self.input_a = inputs[0]
+        self.input_b = inputs[1]
+        self.output = output
 
         self.declare_input(self.input_a, self.vocab)
         self.declare_input(self.input_b, self.vocab)

--- a/nengo_spa/modules/bind.py
+++ b/nengo_spa/modules/bind.py
@@ -1,6 +1,5 @@
 from nengo.params import BoolParam, Default, IntParam
 
-import nengo_spa
 from nengo_spa.network import Network
 from nengo_spa.vocab import VocabularyOrDimParam
 

--- a/nengo_spa/modules/superposition.py
+++ b/nengo_spa/modules/superposition.py
@@ -1,0 +1,52 @@
+from nengo.params import Default, IntParam
+
+from nengo_spa.network import Network
+from nengo_spa.vocab import VocabularyOrDimParam
+
+
+class Superposition(Network):
+    """Network for superposing multiple inputs.
+
+    Parameters
+    ----------
+    n_inputs : int
+        Number of inputs.
+    vocab : Vocabulary or int
+        The vocabulary to use to interpret the vector. If an integer is given,
+        the default vocabulary of that dimensionality will be used.
+    neurons_per_dimension : int, optional (Default: 200)
+        Number of neurons to use in each dimension.
+    kwargs : dict
+        Keyword arguments passed through to `nengo_spa.Network`.
+
+    Attributes
+    ----------
+    inputs : sequence
+        Inputs.
+    output : nengo.Node
+        Output.
+    """
+
+    vocab = VocabularyOrDimParam('vocab', default=None, readonly=True)
+    neurons_per_dimension = IntParam(
+        'neurons_per_dimension', default=200, low=1, readonly=True)
+    n_inputs = IntParam('n_inputs', optional=False, low=1, readonly=True)
+
+    def __init__(self, n_inputs, vocab=Default, neurons_per_dimension=Default,
+                 **kwargs):
+        kwargs.setdefault('label', "Superposition")
+        super(Superposition, self).__init__(**kwargs)
+
+        self.vocab = vocab
+        self.neurons_per_dimension = neurons_per_dimension
+        self.n_inputs = n_inputs
+
+        with self:
+            self.superposition_net, self.inputs, self.output = (
+                self.vocab.algebra.implement_superposition(
+                    self.neurons_per_dimension, self.vocab.dimensions,
+                    self.n_inputs))
+
+        for inp in self.inputs:
+            self.declare_input(inp, self.vocab)
+        self.declare_output(self.output, self.vocab)

--- a/nengo_spa/modules/tests/test_assoc_mem.py
+++ b/nengo_spa/modules/tests/test_assoc_mem.py
@@ -8,7 +8,7 @@ from nengo_spa import Vocabulary
 from nengo_spa.modules.assoc_mem import (
     ThresholdingAssocMem, WTAAssocMem, IAAssocMem)
 from nengo_spa.examine import similarity
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 filtered_step_fn = lambda x: np.maximum(1. - np.exp(-15. * x), 0.)
@@ -43,8 +43,8 @@ def test_am_basic(Simulator, plt, seed, rng):
     plt.plot(t[t > 0.15], np.ones(t.shape)[t > 0.15] * 0.95, c='g', lw=2)
     plt.ylabel("Output")
 
-    assert sp_close(t, sim.data[in_p], vocab['A'], skip=0.15, atol=0.05)
-    assert sp_close(t, sim.data[out_p], vocab['A'], skip=0.15)
+    assert_sp_close(t, sim.data[in_p], vocab['A'], skip=0.15, atol=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab['A'], skip=0.15)
 
 
 def test_am_threshold(Simulator, plt, seed, rng):
@@ -85,7 +85,7 @@ def test_am_threshold(Simulator, plt, seed, rng):
     plt.ylabel("Output")
 
     assert np.mean(sim.data[out_p][below_th]) < 0.01
-    assert sp_close(t, sim.data[out_p], vocab2['B'], skip=0.25, duration=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab2['B'], skip=0.25, duration=0.05)
 
 
 def test_am_wta(Simulator, plt, seed, rng):
@@ -130,8 +130,8 @@ def test_am_wta(Simulator, plt, seed, rng):
     plt.plot(t[more_b], np.ones(t.shape)[more_b] * 0.9, c='g', lw=2)
     plt.ylabel("Output")
 
-    assert sp_close(t, sim.data[out_p], vocab['A'], skip=0.15, duration=0.05)
-    assert sp_close(t, sim.data[out_p], vocab['B'], skip=0.45, duration=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab['A'], skip=0.15, duration=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab['B'], skip=0.45, duration=0.05)
 
 
 def test_am_ia(Simulator, plt, seed, rng):
@@ -176,8 +176,8 @@ def test_am_ia(Simulator, plt, seed, rng):
     plt.plot(t[more_b], np.ones(t.shape)[more_b] * 0.9, c='tab:orange', lw=2)
     plt.ylabel("Output")
 
-    assert sp_close(t, sim.data[out_p], vocab['A'], skip=0.15, duration=0.05)
-    assert sp_close(t, sim.data[out_p], vocab['B'], skip=0.65, duration=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab['A'], skip=0.15, duration=0.05)
+    assert_sp_close(t, sim.data[out_p], vocab['B'], skip=0.65, duration=0.05)
 
 
 def test_am_default_output(Simulator, plt, seed, rng):

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import nengo_spa as spa
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 def test_basic():
@@ -76,6 +76,6 @@ def test_unbind(Simulator, algebra, side, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.15,
         atol=0.3)

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -21,11 +21,11 @@ def test_basic():
 
 def test_run(Simulator, algebra, seed):
     rng = np.random.RandomState(seed)
-    vocab = spa.Vocabulary(32, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
-    with spa.Network(seed=seed, vocabs=VocabularyMap([vocab])) as model:
-        model.bind = spa.Bind(vocab=32)
+    with spa.Network(seed=seed) as model:
+        model.bind = spa.Bind(vocab)
 
         def inputA(t):
             if 0 <= t < 0.1:

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -21,7 +21,7 @@ def test_basic():
 
 def test_run(Simulator, algebra, seed):
     rng = np.random.RandomState(seed)
-    vocab = spa.Vocabulary(64, rng=rng, algebra=algebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=algebra)
     vocab.populate('A; B')
 
     with spa.Network(seed=seed) as model:
@@ -44,10 +44,10 @@ def test_run(Simulator, algebra, seed):
         sim.run(0.2)
 
     error = rmse(vocab.parse("(B*A).normalized()").v, sim.data[p][-1])
-    assert error < 0.1
+    assert error < 0.15
 
     error = rmse(vocab.parse("(A*A).normalized()").v, sim.data[p][100])
-    assert error < 0.1
+    assert error < 0.15
 
 
 @pytest.mark.parametrize('side', ('left', 'right'))

--- a/nengo_spa/modules/tests/test_transcode.py
+++ b/nengo_spa/modules/tests/test_transcode.py
@@ -6,7 +6,7 @@ import pytest
 
 import nengo_spa as spa
 from nengo_spa.modules.transcode import Transcode
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 def test_fixed(Simulator, seed):
@@ -23,9 +23,9 @@ def test_fixed(Simulator, seed):
     with Simulator(model) as sim:
         sim.run(0.1)
 
-    assert sp_close(sim.trange(), sim.data[p1], model.buffer1.vocab.parse('A'),
+    assert_sp_close(sim.trange(), sim.data[p1], model.buffer1.vocab.parse('A'),
                     skip=0.08)
-    assert sp_close(sim.trange(), sim.data[p2], model.buffer2.vocab.parse('B'),
+    assert_sp_close(sim.trange(), sim.data[p2], model.buffer2.vocab.parse('B'),
                     skip=0.08)
 
 
@@ -53,13 +53,13 @@ def test_time_varying_encode(Simulator, seed):
 
     vocab = model.buffer.vocab
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A'), skip=0.08, duration=0.02)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('B'), skip=0.18, duration=0.02)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('C'), skip=0.28, duration=0.02)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('0'), skip=0.38, duration=0.02)
 
 
@@ -82,8 +82,8 @@ def test_encode_with_input(Simulator, seed):
         sim.run(0.4)
 
     vocab = buffer.vocab
-    assert sp_close(sim.trange(), sim.data[p], vocab.parse('0'), duration=0.2)
-    assert sp_close(
+    assert_sp_close(sim.trange(), sim.data[p], vocab.parse('0'), duration=0.2)
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A'), skip=.38, duration=0.02)
 
 
@@ -101,7 +101,7 @@ def test_transcode(Simulator, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    assert sp_close(sim.trange(), sim.data[p],
+    assert_sp_close(sim.trange(), sim.data[p],
                     transcode.output_vocab.parse('B'))
 
 
@@ -114,7 +114,7 @@ def test_passthrough(Simulator, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    assert sp_close(sim.trange(), sim.data[p],
+    assert_sp_close(sim.trange(), sim.data[p],
                     passthrough.output_vocab.parse('A'), skip=0.18)
 
 

--- a/nengo_spa/networks/__init__.py
+++ b/nengo_spa/networks/__init__.py
@@ -8,3 +8,4 @@ from . import selection
 from .circularconvolution import CircularConvolution
 from .identity_ensemble_array import IdentityEnsembleArray
 from .matrix_multiplication import MatrixMult
+from .vtb import VTB

--- a/nengo_spa/networks/__init__.py
+++ b/nengo_spa/networks/__init__.py
@@ -7,3 +7,4 @@ vocabularies and are completely independent of SPA specifics.
 from . import selection
 from .circularconvolution import CircularConvolution
 from .identity_ensemble_array import IdentityEnsembleArray
+from .matrix_multiplication import MatrixMult

--- a/nengo_spa/networks/circularconvolution.py
+++ b/nengo_spa/networks/circularconvolution.py
@@ -98,7 +98,6 @@ def CircularConvolution(n_neurons, dimensions, invert_a=False, invert_b=False,
         Number of neurons to use in each product computation.
     dimensions : int
         The number of dimensions of the input and output vectors.
-
     invert_a : bool, optional
         Whether to reverse the order of elements in first input.
     invert_b : bool, optional

--- a/nengo_spa/networks/circularconvolution.py
+++ b/nengo_spa/networks/circularconvolution.py
@@ -6,17 +6,6 @@ from nengo.networks.product import Product
 from nengo.utils.compat import range
 
 
-def circconv(a, b, invert_a=False, invert_b=False, axis=-1):
-    """A reference Numpy implementation of circular convolution"""
-    A = np.fft.fft(a, axis=axis)
-    B = np.fft.fft(b, axis=axis)
-    if invert_a:
-        A = A.conj()
-    if invert_b:
-        B = B.conj()
-    return np.fft.ifft(A * B, axis=axis).real
-
-
 def transform_in(dims, align, invert):
     """Create a transform to map the input into the Fourier domain.
 

--- a/nengo_spa/networks/matrix_multiplication.py
+++ b/nengo_spa/networks/matrix_multiplication.py
@@ -1,0 +1,99 @@
+import nengo
+import numpy as np
+
+
+def MatrixMult(n_neurons, shape_left, shape_right, net=None):
+    """Computes the matrix product A*B.
+
+    Both matrices need to be two dimensional.
+
+    See the `Matrix Multiplication example <:doc:networks>`_
+    for a description of the network internals.
+
+    Parameters
+    ----------
+    n_neurons : int
+        Number of neurons used per product of two scalars.
+
+        .. note:: If an odd number of neurons is given, one less neuron will be
+                  used per product to obtain an even number. This is due to
+                  the implementation the `.Product` network.
+    shape_left : tuple
+        Shape of the A input matrix.
+    shape_right : tuple
+        Shape of the B input matrix.
+    net : Network, optional (Default: None)
+        A network in which the network components will be built.
+        This is typically used to provide a custom set of Nengo object
+        defaults through modifying ``net.config``.
+
+    Returns
+    -------
+    net : Network
+        The newly built matrix multiplication network, or the provided ``net``.
+    """
+
+    if len(shape_left) != 2:
+        raise ValueError("Shape {} is not two dimensional.".format(shape_left))
+    if len(shape_right) != 2:
+        raise ValueError(
+            "Shape {} is not two dimensional.".format(shape_right))
+    if shape_left[1] != shape_right[0]:
+        raise ValueError(
+            "Matrix dimensions {} and  {} are incompatible".format(
+                shape_left, shape_right))
+
+    if net is None:
+        net = nengo.Network(label="Matrix multiplication")
+
+    size_left = np.prod(shape_left)
+    size_right = np.prod(shape_right)
+
+    with net:
+        net.input_left = nengo.Node(size_in=size_left)
+        net.input_right = nengo.Node(size_in=size_right)
+
+        # The C matrix is composed of populations that each contain
+        # one element of A (left) and one element of B (right).
+        # These elements will be multiplied together in the next step.
+        size_c = size_left * shape_right[1]
+        net.C = nengo.networks.Product(n_neurons, size_c)
+
+        # Determine the transformation matrices to get the correct pairwise
+        # products computed.  This looks a bit like black magic but if
+        # you manually try multiplying two matrices together, you can see
+        # the underlying pattern.  Basically, we need to build up D1*D2*D3
+        # pairs of numbers in C to compute the product of.  If i,j,k are the
+        # indexes into the D1*D2*D3 products, we want to compute the product
+        # of element (i,j) in A with the element (j,k) in B.  The index in
+        # A of (i,j) is j+i*D2 and the index in B of (j,k) is k+j*D3.
+        # The index in C is j+k*D2+i*D2*D3, multiplied by 2 since there are
+        # two values per ensemble.  We add 1 to the B index so it goes into
+        # the second value in the ensemble.
+        transform_left = np.zeros((size_c, size_left))
+        transform_right = np.zeros((size_c, size_right))
+
+        for i, j, k in np.ndindex(shape_left[0], *shape_right):
+            c_index = (j + k * shape_right[0] + i * size_right)
+            transform_left[c_index][j + i * shape_right[0]] = 1
+            transform_right[c_index][k + j * shape_right[1]] = 1
+
+        nengo.Connection(
+            net.input_left, net.C.A, transform=transform_left, synapse=None)
+        nengo.Connection(
+            net.input_right, net.C.B, transform=transform_right, synapse=None)
+
+        # Now do the appropriate summing
+        size_output = shape_left[0] * shape_right[1]
+        net.output = nengo.Node(size_in=size_output)
+
+        # The mapping for this transformation is much easier, since we want to
+        # combine D2 pairs of elements (we sum D2 products together)
+        transform_c = np.zeros((size_output, size_c))
+        for i in range(size_c):
+            transform_c[i // shape_right[0]][i] = 1
+
+        nengo.Connection(
+            net.C.output, net.output, transform=transform_c, synapse=None)
+
+    return net

--- a/nengo_spa/networks/matrix_multiplication.py
+++ b/nengo_spa/networks/matrix_multiplication.py
@@ -2,7 +2,7 @@ import nengo
 import numpy as np
 
 
-def MatrixMult(n_neurons, shape_left, shape_right, net=None):
+def MatrixMult(n_neurons, shape_left, shape_right, **kwargs):
     """Computes the matrix product A*B.
 
     Both matrices need to be two dimensional.
@@ -22,15 +22,19 @@ def MatrixMult(n_neurons, shape_left, shape_right, net=None):
         Shape of the A input matrix.
     shape_right : tuple
         Shape of the B input matrix.
-    net : Network, optional (Default: None)
-        A network in which the network components will be built.
-        This is typically used to provide a custom set of Nengo object
-        defaults through modifying ``net.config``.
+    kwargs : dict
+        Arguments to pass through to the `nengo.Network` constructor.
 
     Returns
     -------
     net : Network
-        The newly built matrix multiplication network, or the provided ``net``.
+        The newly built matrix multiplication network with attributes:
+
+         * **input_left** (`nengo.Node`): The left matrix (A) to multiply.
+         * **input_right** (`nengo.Node`): The left matrix (A) to multiply.
+         * **C** (`nengo.networks.Product`): The product network doing the
+           matrix multiplication.
+         * **output** (`nengo.node`): The resulting matrix result.
     """
 
     if len(shape_left) != 2:
@@ -43,13 +47,10 @@ def MatrixMult(n_neurons, shape_left, shape_right, net=None):
             "Matrix dimensions {} and  {} are incompatible".format(
                 shape_left, shape_right))
 
-    if net is None:
-        net = nengo.Network(label="Matrix multiplication")
-
     size_left = np.prod(shape_left)
     size_right = np.prod(shape_right)
 
-    with net:
+    with nengo.Network(**kwargs) as net:
         net.input_left = nengo.Node(size_in=size_left)
         net.input_right = nengo.Node(size_in=size_right)
 

--- a/nengo_spa/networks/tests/test_circularconv.py
+++ b/nengo_spa/networks/tests/test_circularconv.py
@@ -16,12 +16,12 @@ def test_circularconv_transforms(invert_a, invert_b, rng):
     dims = 100
     x = a = rng.randn(dims)
     y = b = rng.randn(dims)
-    inv = CircularConvolutionAlgebra.get_inversion_matrix(dims)
+    inv = CircularConvolutionAlgebra().get_inversion_matrix(dims)
     if invert_a:
         a = np.dot(inv, a)
     if invert_b:
         b = np.dot(inv, b)
-    z0 = CircularConvolutionAlgebra.bind(a, b)
+    z0 = CircularConvolutionAlgebra().bind(a, b)
 
     tr_a = transform_in(dims, 'A', invert_a)
     tr_b = transform_in(dims, 'B', invert_b)
@@ -42,7 +42,7 @@ def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
 
     a = rng.normal(scale=np.sqrt(1./dims), size=dims) * magnitude
     b = rng.normal(scale=np.sqrt(1./dims), size=dims) * magnitude
-    result = CircularConvolutionAlgebra.bind(a, b)
+    result = CircularConvolutionAlgebra().bind(a, b)
 
     model = nengo.Network(label="circular conv", seed=seed)
     model.config[nengo.Ensemble].neuron_type = nengo.LIFRate()
@@ -77,7 +77,7 @@ def test_neural_accuracy(Simulator, seed, rng, dims, neurons_per_product=128):
     b = rng.normal(scale=np.sqrt(1./dims), size=dims)
     a /= np.linalg.norm(a)
     b /= np.linalg.norm(b)
-    result = CircularConvolutionAlgebra.bind(a, b)
+    result = CircularConvolutionAlgebra().bind(a, b)
 
     model = nengo.Network(label="circular conv", seed=seed)
     model.config[nengo.Ensemble].neuron_type = nengo.LIFRate()

--- a/nengo_spa/networks/tests/test_identity_ensemble_array.py
+++ b/nengo_spa/networks/tests/test_identity_ensemble_array.py
@@ -5,7 +5,7 @@ import pytest
 
 from nengo_spa.networks.identity_ensemble_array import IdentityEnsembleArray
 from nengo_spa.pointer import Identity, SemanticPointer
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 @pytest.mark.parametrize('pointer', [Identity, SemanticPointer])
@@ -46,7 +46,7 @@ def test_add_output(Simulator, seed, rng, plt):
         sim.run(0.3)
 
     plt.plot(sim.trange(), np.dot(sim.data[p], -pointer.v))
-    assert sp_close(sim.trange(), sim.data[p], -pointer, skip=0.2, atol=0.3)
+    assert_sp_close(sim.trange(), sim.data[p], -pointer, skip=0.2, atol=0.3)
 
 
 def test_add_output_multiple_fn(Simulator, seed, rng, plt):
@@ -71,7 +71,7 @@ def test_add_output_multiple_fn(Simulator, seed, rng, plt):
     expected = SemanticPointer(v)
 
     plt.plot(sim.trange(), np.dot(sim.data[p], expected.v))
-    assert sp_close(sim.trange(), sim.data[p], expected, skip=0.2, atol=0.3)
+    assert_sp_close(sim.trange(), sim.data[p], expected, skip=0.2, atol=0.3)
 
 
 def test_neuron_connections(Simulator, seed, rng):

--- a/nengo_spa/networks/tests/test_matrix_multiplication.py
+++ b/nengo_spa/networks/tests/test_matrix_multiplication.py
@@ -1,0 +1,34 @@
+import nengo
+import numpy as np
+
+from nengo_spa.networks.matrix_multiplication import MatrixMult
+
+
+def test_matrix_mult(Simulator, seed, rng, plt):
+    shape_left = (2, 2)
+    shape_right = (2, 2)
+
+    left_mat = rng.uniform(-1, 1, size=shape_left)
+    right_mat = rng.uniform(-1, 1, size=shape_right)
+
+    with nengo.Network("Matrix multiplication test", seed=seed) as model:
+        node_left = nengo.Node(left_mat.ravel())
+        node_right = nengo.Node(right_mat.ravel())
+        mult_net = MatrixMult(200, shape_left, shape_right)
+        p = nengo.Probe(mult_net.output, synapse=0.01)
+
+        nengo.Connection(node_left, mult_net.input_left)
+        nengo.Connection(node_right, mult_net.input_right)
+
+    dt = 0.001
+    with Simulator(model, dt=dt) as sim:
+        sim.run(1)
+
+    t = sim.trange()
+    plt.plot(t, sim.data[p])
+    for d in np.dot(left_mat, right_mat).flatten():
+        plt.axhline(d, color='k')
+
+    atol, rtol = .15, .01
+    ideal = np.dot(left_mat, right_mat).ravel()
+    assert np.allclose(sim.data[p][-1], ideal, atol=atol, rtol=rtol)

--- a/nengo_spa/networks/tests/test_vtb.py
+++ b/nengo_spa/networks/tests/test_vtb.py
@@ -10,7 +10,7 @@ from nengo_spa.testing import assert_sp_close
 
 def test_bind(Simulator, seed):
     rng = np.random.RandomState(seed)
-    vocab = spa.Vocabulary(16, rng=rng, algebra=VtbAlgebra)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=VtbAlgebra())
     vocab.populate('A; B')
 
     with spa.Network(seed=seed) as model:
@@ -29,7 +29,7 @@ def test_bind(Simulator, seed):
 @pytest.mark.parametrize('side', ('left', 'right'))
 def test_unbind(Simulator, side, seed):
     rng = np.random.RandomState(seed)
-    vocab = spa.Vocabulary(36, rng=rng, algebra=VtbAlgebra)
+    vocab = spa.Vocabulary(36, rng=rng, algebra=VtbAlgebra())
     vocab.populate('A; B')
 
     with spa.Network(seed=seed) as model:

--- a/nengo_spa/networks/tests/test_vtb.py
+++ b/nengo_spa/networks/tests/test_vtb.py
@@ -5,7 +5,7 @@ import pytest
 import nengo_spa as spa
 from nengo_spa.algebras.vtb import VtbAlgebra
 from nengo_spa.networks.vtb import VTB
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 def test_bind(Simulator, seed):
@@ -22,7 +22,7 @@ def test_bind(Simulator, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.15, atol=0.3)
 
 
@@ -54,6 +54,6 @@ def test_unbind(Simulator, side, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.15,
         atol=0.3)

--- a/nengo_spa/networks/tests/test_vtb.py
+++ b/nengo_spa/networks/tests/test_vtb.py
@@ -1,0 +1,59 @@
+import nengo
+import numpy as np
+import pytest
+
+import nengo_spa as spa
+from nengo_spa.algebras.vtb import VtbAlgebra
+from nengo_spa.networks.vtb import VTB
+from nengo_spa.testing import sp_close
+
+
+def test_bind(Simulator, seed):
+    rng = np.random.RandomState(seed)
+    vocab = spa.Vocabulary(16, rng=rng, algebra=VtbAlgebra)
+    vocab.populate('A; B')
+
+    with spa.Network(seed=seed) as model:
+        vtb = VTB(100, 16)
+        nengo.Connection(nengo.Node(vocab['A'].v), vtb.input_left)
+        nengo.Connection(nengo.Node(vocab['B'].v), vtb.input_right)
+        p = nengo.Probe(vtb.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.2)
+
+    assert sp_close(
+        sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.15, atol=0.3)
+
+
+@pytest.mark.parametrize('side', ('left', 'right'))
+def test_unbind(Simulator, side, seed):
+    rng = np.random.RandomState(seed)
+    vocab = spa.Vocabulary(36, rng=rng, algebra=VtbAlgebra)
+    vocab.populate('A; B')
+
+    with spa.Network(seed=seed) as model:
+        vtb = VTB(
+            100, 36, unbind_left=(side == 'left'),
+            unbind_right=(side == 'right'))
+
+        if side == 'left':
+            left = nengo.Node(vocab['B'].v)
+            right = nengo.Node(vocab.parse('B*A').v)
+        elif side == 'right':
+            left = nengo.Node(vocab.parse('A*B').v)
+            right = nengo.Node(vocab['B'].v)
+        else:
+            raise ValueError("Invalid 'side' value.")
+
+        nengo.Connection(left, vtb.input_left)
+        nengo.Connection(right, vtb.input_right)
+
+        p = nengo.Probe(vtb.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.2)
+
+    assert sp_close(
+        sim.trange(), sim.data[p], vocab.parse('A * B * ~B'), skip=0.15,
+        atol=0.3)

--- a/nengo_spa/networks/vtb.py
+++ b/nengo_spa/networks/vtb.py
@@ -95,6 +95,7 @@ def VTB(n_neurons, dimensions, unbind_left=False, unbind_right=False,
            bound.
          * **mat** (`nengo.Node`): Representation of the matrix :math:`V_y'`.
          * **vec** (`nengo.Node`): Representation of the vector :math:`y`.
+         * **matmuls** (`list`): Matrix multiplication networks.
          * **output** (`nengo.Node`): The resulting bound vector.
     """
     sub_d = calc_sub_d(dimensions)

--- a/nengo_spa/networks/vtb.py
+++ b/nengo_spa/networks/vtb.py
@@ -1,0 +1,149 @@
+import nengo
+from nengo.dists import CosineSimilarity
+from nengo.exceptions import ValidationError
+import numpy as np
+
+from nengo_spa.networks.matrix_multiplication import MatrixMult
+
+
+def calc_sub_d(dimensions):
+    sub_d = int(np.sqrt(dimensions))
+    if sub_d * sub_d != dimensions:
+        raise ValidationError(
+            "Dimensions must be a square number.", 'dimensions')
+    return sub_d
+
+
+def inversion_matrix(dimensions):
+    sub_d = calc_sub_d(dimensions)
+    m = np.zeros((dimensions, dimensions))
+    for i in range(dimensions):
+        j = sub_d * i
+        m[j % dimensions + j // dimensions, i] = 1.
+    return m
+
+
+def swapping_matrix(dimensions):
+    sub_d = calc_sub_d(dimensions)
+    m = np.zeros((dimensions, dimensions))
+    for i in range(dimensions):
+        j = i // sub_d + sub_d * (i % sub_d)
+        m[i, j] = 1.
+    return m
+
+
+def VTB(n_neurons, dimensions, unbind_left=False, unbind_right=False,
+        **kwargs):
+    r"""Compute vector-derived transformation binding (VTB).
+
+    VTB uses elementwise addition for superposition. The binding operation
+    :math:`\mathcal{B}(x, y)` is defined as
+
+    .. math::
+
+       \mathcal{B}(x, y) := V_y x = \left[\begin{array}{ccc}
+           V_y' &    0 &    0 \\
+              0 & V_y' &    0 \\
+              0 &    0 & V_y'
+           \end{array}\right] x
+
+    with
+
+    .. math::
+
+       V_y' = d^{\frac{1}{4}} \left[\begin{array}{cccc}
+           y_1            & y_2            & \dots  & y_{d'}  \\
+           y_{d' + 1}     & y_{d' + 2}     & \dots  & y_{2d'} \\
+           \vdots         & \vdots         & \ddots & \vdots  \\
+           y_{d - d' + 1} & y_{d - d' + 2} & \dots  & y_d
+       \end{array}\right]
+
+    and
+
+    .. math:: d'^2 = d.
+
+    The approximate inverse :math:`y^+` for :math:`y` is permuting the elements
+    such that :math:`V_{y^+} = V_y`.
+
+    Note that VTB requires the vector dimensionality to be square.
+
+    The VTB binding operation is neither associative nor commutative.
+
+    Publications with further information are forthcoming.
+
+    Parameters
+    ----------
+    n_neurons : int
+        Number of neurons to use in each product computation.
+    dimensions : int
+        The number of dimensions of the input and output vectors. Needs to be a
+        square number.
+    unbind_left : bool
+        Whether to unbind the left input vector from the right input vector.
+    unbind_right : bool
+        Whether to unbind the right input vector from the left input vector.
+    kwargs : dict
+        Arguments to pass through to the `nengo.Network` constructor.
+
+    Returns
+    -------
+    nengo.Network
+        The newly built product network with attributes:
+
+         * **input_left** (`nengo.Node`): The left operand vector to be bound.
+         * **input_right** (`nengo.Node`): The right operand vector to be
+           bound.
+         * **mat** (`nengo.Node`): Representation of the matrix :math:`V_y'`.
+         * **vec** (`nengo.Node`): Representation of the vector :math:`y`.
+         * **output** (`nengo.Node`): The resulting bound vector.
+    """
+    sub_d = calc_sub_d(dimensions)
+
+    shape_left = (sub_d, sub_d)
+    shape_right = (sub_d, 1)
+
+    with nengo.Network(**kwargs) as net:
+        net.input_left = nengo.Node(size_in=dimensions)
+        net.input_right = nengo.Node(size_in=dimensions)
+        net.output = nengo.Node(size_in=dimensions)
+
+        net.mat = nengo.Node(size_in=dimensions)
+        net.vec = nengo.Node(size_in=dimensions)
+
+        if unbind_left and unbind_right:
+            raise ValueError("Cannot unbind both sides at the same time.")
+        elif unbind_left:
+            nengo.Connection(
+                net.input_left, net.mat,
+                transform=inversion_matrix(dimensions), synapse=None)
+            nengo.Connection(
+                net.input_right, net.vec,
+                transform=swapping_matrix(dimensions), synapse=None)
+        else:
+            nengo.Connection(net.input_left, net.vec, synapse=None)
+            if unbind_right:
+                tr = inversion_matrix(dimensions)
+            else:
+                tr = 1.
+            nengo.Connection(
+                net.input_right, net.mat, transform=tr, synapse=None)
+
+        with nengo.Config(nengo.Ensemble) as cfg:
+            cfg[nengo.Ensemble].intercepts = CosineSimilarity(
+                dimensions + 2)
+            cfg[nengo.Ensemble].eval_points = CosineSimilarity(
+                dimensions + 2)
+            net.matmuls = [
+                MatrixMult(n_neurons, shape_left, shape_right)
+                for i in range(sub_d)]
+
+        for i in range(sub_d):
+            mm = net.matmuls[i]
+            sl = slice(i * sub_d, (i + 1) * sub_d)
+            nengo.Connection(net.mat, mm.input_left, synapse=None)
+            nengo.Connection(net.vec[sl], mm.input_right, synapse=None)
+            nengo.Connection(
+                mm.output, net.output[sl], transform=np.sqrt(sub_d),
+                synapse=None)
+
+    return net

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -67,7 +67,7 @@ class SemanticPointer(Fixed):
     def _get_algebra(cls, vocab, algebra):
         if algebra is None:
             if vocab is None:
-                algebra = CircularConvolutionAlgebra
+                algebra = CircularConvolutionAlgebra()
             else:
                 algebra = vocab.algebra
         elif vocab is not None and vocab.algebra is not algebra:

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -44,15 +44,7 @@ class SemanticPointer(Fixed):
     def __init__(self, data, rng=None, vocab=None, algebra=None):
         super(SemanticPointer, self).__init__(
             TAnyVocab if vocab is None else TVocabulary(vocab))
-        if algebra is None:
-            if vocab is None:
-                algebra = CircularConvolutionAlgebra
-            else:
-                algebra = vocab.algebra
-        elif vocab is not None:
-            raise ValueError(
-                "vocab and algebra argument are mutually exclusive")
-        self.algebra = algebra
+        self.algebra = self._get_algebra(vocab, algebra)
 
         if rng is None:
             rng = np.random
@@ -71,6 +63,17 @@ class SemanticPointer(Fixed):
         self.v.setflags(write=False)
 
         self.vocab = vocab
+
+    def _get_algebra(cls, vocab, algebra):
+        if algebra is None:
+            if vocab is None:
+                algebra = CircularConvolutionAlgebra
+            else:
+                algebra = vocab.algebra
+        elif vocab is not None:
+            raise ValueError(
+                "vocab and algebra argument are mutually exclusive")
+        return algebra
 
     def evaluate(self):
         return self
@@ -282,20 +285,24 @@ class SemanticPointer(Fixed):
 
 
 class Identity(SemanticPointer):
-    """Circular convolution identity.
+    """Identity element.
 
     Parameters
     ----------
     n_dimensions : int
         Dimensionality of the identity vector.
-    vocab : Vocabulary
+    vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
+        Mutually exclusive with the *algebra* argument.
+    algebra = Algebra, optional
+        Algebra used to perform vector symbolic operations on the Semantic
+        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        with the `vocab` argument.
     """
 
-    def __init__(self, n_dimensions, vocab=None):
-        data = np.zeros(n_dimensions)
-        data[0] = 1.
-        super(Identity, self).__init__(data, vocab=vocab)
+    def __init__(self, n_dimensions, vocab=None, algebra=None):
+        data = self._get_algebra(vocab, algebra).identity_element(n_dimensions)
+        super(Identity, self).__init__(data, vocab=vocab, algebra=algebra)
 
 
 class AbsorbingElement(SemanticPointer):
@@ -309,12 +316,19 @@ class AbsorbingElement(SemanticPointer):
     ----------
     n_dimensions : int
         Dimensionality of the identity vector.
-    vocab : Vocabulary
+    vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
+        Mutually exclusive with the *algebra* argument.
+    algebra = Algebra, optional
+        Algebra used to perform vector symbolic operations on the Semantic
+        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        with the `vocab` argument.
     """
-    def __init__(self, n_dimensions, vocab=None):
-        data = np.ones(n_dimensions) / np.sqrt(n_dimensions)
-        super(AbsorbingElement, self).__init__(data, vocab=vocab)
+    def __init__(self, n_dimensions, vocab=None, algebra=None):
+        data = self._get_algebra(vocab, algebra).absorbing_element(
+            n_dimensions)
+        super(AbsorbingElement, self).__init__(
+            data, vocab=vocab, algebra=algebra)
 
 
 class Zero(SemanticPointer):
@@ -324,8 +338,14 @@ class Zero(SemanticPointer):
     ----------
     n_dimensions : int
         Dimensionality of the identity vector.
-    vocab : Vocabulary
+    vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
+        Mutually exclusive with the *algebra* argument.
+    algebra = Algebra, optional
+        Algebra used to perform vector symbolic operations on the Semantic
+        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        with the `vocab` argument.
     """
-    def __init__(self, n_dimensions, vocab=None):
-        super(Zero, self).__init__(np.zeros(n_dimensions), vocab=vocab)
+    def __init__(self, n_dimensions, vocab=None, algebra=None):
+        data = self._get_algebra(vocab, algebra).zero_element(n_dimensions)
+        super(Zero, self).__init__(data, vocab=vocab, algebra=algebra)

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -228,13 +228,13 @@ class SemanticPointer(Fixed):
             data=self.algebra.bind(other.evaluate().v, self.v), vocab=vocab,
             algebra=self.algebra)
 
-    def get_binding_matrix(self):
+    def get_binding_matrix(self, swap_inputs=False):
         """Return the matrix that does a binding with this vector.
 
         This should be such that
         ``A*B == dot(A.get_binding_matrix(), B.v)``.
         """
-        return self.algebra.get_binding_matrix(self.v)
+        return self.algebra.get_binding_matrix(self.v, swap_inputs=swap_inputs)
 
     def dot(self, other):
         """Return the dot product of the two vectors."""

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -25,7 +25,7 @@ class SemanticPointer(Fixed):
     vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
         Mutually exclusive with the *algebra* argument.
-    algebra = Algebra, optional
+    algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the *vocab* argument.
@@ -34,7 +34,7 @@ class SemanticPointer(Fixed):
     ----------
     v : array_like
         The vector constituting the Semantic Pointer.
-    algebra : Algebra
+    algebra : AbstractAlgebra
         Algebra that defines the vector symbolic operations on this Semantic
         Pointer.
     vocab : Vocabulary or None
@@ -305,7 +305,7 @@ class Identity(SemanticPointer):
     vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
         Mutually exclusive with the *algebra* argument.
-    algebra = Algebra, optional
+    algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the `vocab` argument.
@@ -317,11 +317,11 @@ class Identity(SemanticPointer):
 
 
 class AbsorbingElement(SemanticPointer):
-    r"""Circular convolution absorbing element.
+    r"""Absorbing element.
 
     If :math:`z` denotes the absorbing element, :math:`v \circledast z = c z`,
     where :math:`v` is a Semantic Pointer and :math:`c` is a real-valued
-    scalar.
+    scalar. Furthermore :math:`\|z\| = 1`.
 
     Parameters
     ----------
@@ -330,7 +330,7 @@ class AbsorbingElement(SemanticPointer):
     vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
         Mutually exclusive with the *algebra* argument.
-    algebra = Algebra, optional
+    algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the `vocab` argument.
@@ -343,7 +343,7 @@ class AbsorbingElement(SemanticPointer):
 
 
 class Zero(SemanticPointer):
-    """An all zero Semantic Pointer.
+    """Zero element.
 
     Parameters
     ----------
@@ -352,7 +352,7 @@ class Zero(SemanticPointer):
     vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
         Mutually exclusive with the *algebra* argument.
-    algebra = Algebra, optional
+    algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the `vocab` argument.

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -70,7 +70,7 @@ class SemanticPointer(Fixed):
                 algebra = CircularConvolutionAlgebra
             else:
                 algebra = vocab.algebra
-        elif vocab is not None:
+        elif vocab is not None and vocab.algebra is not algebra:
             raise ValueError(
                 "vocab and algebra argument are mutually exclusive")
         return algebra
@@ -92,7 +92,8 @@ class SemanticPointer(Fixed):
         """
         nrm = np.linalg.norm(self.v)
         if nrm > 0:
-            return SemanticPointer(self.v / nrm, vocab=self.vocab)
+            return SemanticPointer(
+                self.v / nrm, vocab=self.vocab, algebra=self.algebra)
 
     def unitary(self):
         """Make the Semantic Pointer unitary and return it as a new object.
@@ -104,11 +105,13 @@ class SemanticPointer(Fixed):
         convolution.
         """
         return SemanticPointer(
-            self.algebra.make_unitary(self.v), vocab=self.vocab)
+            self.algebra.make_unitary(self.v), vocab=self.vocab,
+            algebra=self.algebra)
 
     def copy(self):
         """Return another semantic pointer with the same data."""
-        return SemanticPointer(data=self.v, vocab=self.vocab)
+        return SemanticPointer(
+            data=self.v, vocab=self.vocab, algebra=self.algebra)
 
     def length(self):
         """Return the L2 norm of the vector."""
@@ -128,7 +131,7 @@ class SemanticPointer(Fixed):
         if vocab is None:
             self._ensure_algebra_match(other)
         return SemanticPointer(data=self.algebra.superpose(
-            self.v, other.evaluate().v), vocab=vocab)
+            self.v, other.evaluate().v), vocab=vocab, algebra=self.algebra)
 
     @TypeCheckedBinaryOp(Fixed)
     def __radd__(self, other):
@@ -137,10 +140,11 @@ class SemanticPointer(Fixed):
         if vocab is None:
             self._ensure_algebra_match(other)
         return SemanticPointer(data=self.algebra.superpose(
-            other.evaluate().v, self.v), vocab=vocab)
+            other.evaluate().v, self.v), vocab=vocab, algebra=self.algebra)
 
     def __neg__(self):
-        return SemanticPointer(data=-self.v, vocab=self.vocab)
+        return SemanticPointer(
+            data=-self.v, vocab=self.vocab, algebra=self.algebra)
 
     def __sub__(self, other):
         return self + (-other)
@@ -158,11 +162,13 @@ class SemanticPointer(Fixed):
                 "Multiplication of Semantic Pointers with arrays in not "
                 "allowed.")
         elif is_number(other):
-            return SemanticPointer(data=self.v * other, vocab=self.vocab)
+            return SemanticPointer(
+                data=self.v * other, vocab=self.vocab, algebra=self.algebra)
         elif isinstance(other, Fixed):
             if other.type == TScalar:
                 return SemanticPointer(
-                    data=self.v * other.evaluate(), vocab=self.vocab)
+                    data=self.v * other.evaluate(), vocab=self.vocab,
+                    algebra=self.algebra)
             else:
                 return self.bind(other)
         else:
@@ -178,11 +184,13 @@ class SemanticPointer(Fixed):
                 "Multiplication of Semantic Pointers with arrays in not "
                 "allowed.")
         elif is_number(other):
-            return SemanticPointer(data=self.v * other, vocab=self.vocab)
+            return SemanticPointer(
+                data=self.v * other, vocab=self.vocab, algebra=self.algebra)
         elif isinstance(other, Fixed):
             if other.type == TScalar:
                 return SemanticPointer(
-                    data=self.v * other.evaluate(), vocab=self.vocab)
+                    data=self.v * other.evaluate(), vocab=self.vocab,
+                    algebra=self.algebra)
             else:
                 return self.rbind(other)
         else:
@@ -197,7 +205,8 @@ class SemanticPointer(Fixed):
         For the vector ``[1, 2, 3, 4, 5]``, the inverse is ``[1, 5, 4, 3, 2]``.
         """
         return SemanticPointer(
-            data=self.algebra.invert(self.v), vocab=self.vocab)
+            data=self.algebra.invert(self.v), vocab=self.vocab,
+            algebra=self.algebra)
 
     def bind(self, other):
         """Return the binding of two SemanticPointers."""
@@ -206,7 +215,8 @@ class SemanticPointer(Fixed):
         if vocab is None:
             self._ensure_algebra_match(other)
         return SemanticPointer(
-            data=self.algebra.bind(self.v, other.evaluate().v), vocab=vocab)
+            data=self.algebra.bind(self.v, other.evaluate().v), vocab=vocab,
+            algebra=self.algebra)
 
     def rbind(self, other):
         """Return the binding of two SemanticPointers."""
@@ -215,7 +225,8 @@ class SemanticPointer(Fixed):
         if vocab is None:
             self._ensure_algebra_match(other)
         return SemanticPointer(
-            data=self.algebra.bind(other.evaluate().v, self.v), vocab=vocab)
+            data=self.algebra.bind(other.evaluate().v, self.v), vocab=vocab,
+            algebra=self.algebra)
 
     def get_binding_matrix(self):
         """Return the matrix that does a binding with this vector.

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -297,7 +297,7 @@ class Identity(SemanticPointer):
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
-        with the `vocab` argument.
+        with the *vocab* argument.
     """
 
     def __init__(self, n_dimensions, vocab=None, algebra=None):
@@ -322,7 +322,7 @@ class AbsorbingElement(SemanticPointer):
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
-        with the `vocab` argument.
+        with the *vocab* argument.
     """
     def __init__(self, n_dimensions, vocab=None, algebra=None):
         data = self._get_algebra(vocab, algebra).absorbing_element(
@@ -344,7 +344,7 @@ class Zero(SemanticPointer):
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
-        with the `vocab` argument.
+        with the *vocab* argument.
     """
     def __init__(self, n_dimensions, vocab=None, algebra=None):
         data = self._get_algebra(vocab, algebra).zero_element(n_dimensions)

--- a/nengo_spa/testing.py
+++ b/nengo_spa/testing.py
@@ -34,7 +34,7 @@ def assert_sp_close(
     if normalized:
         actual /= np.expand_dims(np.linalg.norm(actual, axis=1), 1)
         expected = expected.normalized()
-    error = np.sqrt(np.sum(np.square(actual - expected.v), axis=1))
+    error = np.sqrt(np.mean(np.square(actual - expected.v), axis=1))
     assert np.all(error < atol), \
         "Absolute tolerance exceeded (mean={}, min={}, max={})".format(
             np.mean(error), np.min(error), np.max(error))

--- a/nengo_spa/testing.py
+++ b/nengo_spa/testing.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def sp_close(
+def assert_sp_close(
         t, data, target_sp, skip=0., duration=None, atol=0.2,
         normalized=False):
     """Test that the RMSE to a Semantic Pointer is below threshold.
@@ -26,11 +26,6 @@ def sp_close(
     normalize : bool, optional
         Whether to normalize the simulation data to unit length in each
         timestep.
-
-    Returns
-    -------
-    bool
-        *True* if *atol* is not exceeded during the considered time interval.
     """
     if duration is None:
         duration = np.max(t) - skip
@@ -39,5 +34,7 @@ def sp_close(
     if normalized:
         actual /= np.expand_dims(np.linalg.norm(actual, axis=1), 1)
         expected = expected.normalized()
-    return np.all(np.sqrt(np.sum(
-        np.square(actual - expected.v), axis=1)) < atol)
+    error = np.sqrt(np.sum(np.square(actual - expected.v), axis=1))
+    assert np.all(error < atol), \
+        "Absolute tolerance exceeded (mean={}, min={}, max={})".format(
+            np.mean(error), np.min(error), np.max(error))

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -278,8 +278,8 @@ def test_non_default_input_and_output(Simulator, rng):
         a = spa.Transcode('A', output_vocab=vocab)
         b = spa.Transcode('B', output_vocab=vocab)
         bind = spa.Bind(vocab)
-        a.output >> bind.input_a
-        b.output >> bind.input_b
+        a.output >> bind.input_left
+        b.output >> bind.input_right
         p = nengo.Probe(bind.output, synapse=0.03)
 
     with Simulator(model) as sim:

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -7,7 +7,7 @@ import nengo_spa as spa
 from nengo_spa.actions import ActionSelection
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaActionSelectionError, SpaTypeError
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 
 
 def test_new_action_syntax(Simulator, seed, plt, rng):
@@ -216,7 +216,7 @@ def test_assignment_of_pointer_symbol(Simulator, rng):
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
+    assert_sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
 
 
 def test_assignment_of_dynamic_scalar(Simulator, rng):
@@ -267,7 +267,7 @@ def test_assignment_of_dynamic_pointer(Simulator, rng):
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
+    assert_sp_close(sim.trange(), sim.data[p], vocab['A'], skip=0.3)
 
 
 def test_non_default_input_and_output(Simulator, rng):
@@ -285,7 +285,7 @@ def test_non_default_input_and_output(Simulator, rng):
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse('A*B'), skip=0.3, atol=0.3)
 
 
@@ -319,14 +319,14 @@ def test_action_selection(Simulator, rng):
 
     t = sim.trange()
     assert_allclose(sim.data[p_scalar][(0.3 < t) & (t <= 0.5)], 0.5, atol=0.2)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p_pointer], vocab['B'], skip=0.8, duration=0.2)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p_pointer], vocab['C'], skip=1.3, duration=0.2)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p_pointer], vocab['D'], skip=1.8, duration=0.2)
     assert_allclose(sim.data[p_scalar][(2.3 < t) & (t <= 2.5)], 0.25, atol=0.2)
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p_pointer], vocab['E'], skip=2.3, duration=0.2)
 
 

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_equal
 import pytest
 
 import nengo_spa as spa
-from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
+from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.pointer import AbsorbingElement, Identity, SemanticPointer, Zero
@@ -256,14 +256,8 @@ def test_binary_operation_on_fixed_pointer_with_pointer_symbol(
 
 @pytest.mark.parametrize('op', ('+', '*'))
 def test_incompatible_algebra(op):
-    class AlgA(CircularConvolutionAlgebra):
-        pass
-
-    class AlgB(CircularConvolutionAlgebra):
-        pass
-
-    a = SemanticPointer(32, algebra=AlgA)  # noqa: F841
-    b = SemanticPointer(32, algebra=AlgB)  # noqa: F841
+    a = SemanticPointer(32, algebra=AbstractAlgebra())  # noqa: F841
+    b = SemanticPointer(32, algebra=AbstractAlgebra())  # noqa: F841
     with pytest.raises(TypeError):
         eval('a' + op + 'b')
 

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -260,24 +260,15 @@ def test_incompatible_algebra(op):
         eval('a' + op + 'b')
 
 
-def test_identity(rng):
-    p = Identity(64)
-    assert len(p) == 64
-    assert np.sum(p.v) == 1.
-    a = SemanticPointer(64, rng)
-    assert np.allclose(a.v, (a * p).v)
+def test_identity(algebra):
+    assert np.allclose(
+        Identity(64, algebra=algebra).v, algebra.identity_element(64))
 
 
-def test_absorbing_element(rng):
-    p = AbsorbingElement(64)
-    assert len(p) == 64
-    assert p.length() == 1.
-    a = SemanticPointer(64, rng)
-    assert np.allclose(p.v, np.abs((a * p).normalized().v))
-    assert np.allclose(p.v, np.abs((a * -p).normalized().v))
+def test_absorbing_element(algebra):
+    assert np.allclose(
+        AbsorbingElement(64, algebra=algebra).v, algebra.absorbing_element(64))
 
 
-def test_zero():
-    z = Zero(64)
-    assert len(z) == 64
-    assert np.all(z.v == 0.)
+def test_zero(algebra):
+    assert np.allclose(Zero(64, algebra=algebra).v, algebra.zero_element(64))

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -189,8 +189,10 @@ def test_binding_matrix(algebra, rng):
     b = SemanticPointer(64, rng, algebra=algebra)
 
     m = b.get_binding_matrix()
+    m_swapped = a.get_binding_matrix(swap_inputs=True)
 
     assert np.allclose((a*b).v, np.dot(m, a.v))
+    assert np.allclose((a*b).v, np.dot(m_swapped, b.v))
 
 
 @pytest.mark.parametrize('op', ('~a', '-a', 'a+a', 'a-a', 'a*a', '2*a'))

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -65,8 +65,11 @@ def test_str():
     assert str(a) == str(np.array([1., 1.]))
 
 
-@pytest.mark.parametrize('d', [65, 100])
+@pytest.mark.parametrize('d', [64, 65, 100])
 def test_make_unitary(algebra, d, rng):
+    if not algebra.is_valid_dimensionality(d):
+        return
+
     a = SemanticPointer(d, rng=rng, algebra=algebra)
     b = a.unitary()
     assert a is not b
@@ -92,9 +95,12 @@ def test_add_sub(algebra, rng):
 
 @pytest.mark.parametrize('d', [64, 65])
 def test_binding_and_inversion(algebra, d, rng):
+    if not algebra.is_valid_dimensionality(d):
+        return
+
     a = SemanticPointer(d, rng=rng, algebra=algebra)
     b = SemanticPointer(d, rng=rng, algebra=algebra)
-    identity = SemanticPointer(np.eye(d)[0], algebra=algebra)
+    identity = Identity(d, algebra=algebra)
 
     c = a.copy()
     c *= b
@@ -179,8 +185,8 @@ def test_mse():
 
 
 def test_binding_matrix(algebra, rng):
-    a = SemanticPointer(50, rng, algebra=algebra)
-    b = SemanticPointer(50, rng, algebra=algebra)
+    a = SemanticPointer(64, rng, algebra=algebra)
+    b = SemanticPointer(64, rng, algebra=algebra)
 
     m = b.get_binding_matrix()
 
@@ -266,8 +272,12 @@ def test_identity(algebra):
 
 
 def test_absorbing_element(algebra):
-    assert np.allclose(
-        AbsorbingElement(64, algebra=algebra).v, algebra.absorbing_element(64))
+    try:
+        assert np.allclose(
+            AbsorbingElement(64, algebra=algebra).v,
+            algebra.absorbing_element(64))
+    except NotImplementedError:
+        pass
 
 
 def test_zero(algebra):

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -12,7 +12,7 @@ from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.pointer import AbsorbingElement, Identity, SemanticPointer, Zero
-from nengo_spa.testing import sp_close
+from nengo_spa.testing import assert_sp_close
 from nengo_spa.types import TVocabulary
 from nengo_spa.vocab import Vocabulary
 
@@ -249,7 +249,7 @@ def test_binary_operation_on_fixed_pointer_with_pointer_symbol(
     with Simulator(model) as sim:
         sim.run(0.5)
 
-    assert sp_close(
+    assert_sp_close(
         sim.trange(), sim.data[p], vocab.parse(order[0] + op + order[1]),
         skip=0.3)
 

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -215,8 +215,8 @@ def test_readonly(rng):
         v1.parse('D')
 
 
-def test_subset(rng):
-    v1 = Vocabulary(32, rng=rng)
+def test_subset(rng, algebra):
+    v1 = Vocabulary(32, rng=rng, algebra=algebra)
     v1.populate('A; B; C; D; E; F; G')
 
     # Test creating a vocabulary subset
@@ -225,6 +225,8 @@ def test_subset(rng):
     assert_equal(v2['A'].v, v1['A'].v)
     assert_equal(v2['C'].v, v1['C'].v)
     assert_equal(v2['E'].v, v1['E'].v)
+
+    assert v1.algebra is v2.algebra
 
 
 def test_vocabulary_tracking(rng):

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -8,7 +8,7 @@ import pytest
 
 from nengo_spa import Vocabulary
 from nengo_spa.exceptions import SpaParseError
-from nengo_spa.pointer import Identity, SemanticPointer
+from nengo_spa.pointer import SemanticPointer
 from nengo_spa.vocab import (
     special_sps, VocabularyMap, VocabularyMapParam, VocabularyOrDimParam)
 
@@ -136,7 +136,8 @@ def test_parse_n(rng):
     assert np.allclose(parsed[0].v, A.v)
     assert np.allclose(parsed[1].v, (A * B).v)
     assert np.allclose(parsed[2].v, (A + B).v)
-    assert np.allclose(parsed[3].v, 3 * Identity(64).v)
+    # FIXME should give an exception?
+    assert np.allclose(parsed[3].v, 3 * v['Identity'].v)
 
 
 def test_invalid_dimensions():

--- a/nengo_spa/version.py
+++ b/nengo_spa/version.py
@@ -1,6 +1,6 @@
 """Nengo SPA version information.
 
-We use semantic versioning (see http://semver.org/).
+We use semantic versioning (see https://semver.org/).
 and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
 '.devN' will be added to the version unless the code base represents
 a release version. Release versions are git tagged with the version.

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -9,6 +9,7 @@ from nengo.utils.compat import is_number, is_integer, range
 import numpy as np
 
 from nengo_spa import pointer
+from nengo_spa.algebras.cconv import CircularConvolutionAlgebra
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.pointer import AbsorbingElement, Identity, Zero
 
@@ -77,6 +78,7 @@ class Vocabulary(Mapping):
     def __init__(
             self, dimensions, strict=True, max_similarity=0.1, rng=None,
             name=None):
+        self.algebra = CircularConvolutionAlgebra()
 
         if not is_integer(dimensions) or dimensions < 1:
             raise ValidationError("dimensions must be a positive integer",
@@ -359,7 +361,7 @@ class Vocabulary(Mapping):
         """
         # Make new Vocabulary object
         subset = Vocabulary(self.dimensions, self.strict, self.max_similarity,
-                            self.rng)
+                            self.rng, algebra=self.algebra)
 
         # Copy over the new keys
         for key in keys:

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -54,6 +54,9 @@ class Vocabulary(Mapping):
         The random number generator to use to create new vectors.
     name : str
         A name to display in the string representation of this vocabulary.
+    algebra : Algebra, optional
+        Defines the vector symbolic operators used for Semantic Pointers in the
+        vocabulary. Defaults to `.CircularConvolutionAlgebra`.
 
     Attributes
     ----------
@@ -73,12 +76,17 @@ class Vocabulary(Mapping):
     vectors : ndarray
         All of the semantic pointer vectors in a matrix, in the same order
         as in `keys`.
+    algebra : Algebra, optional
+        Defines the vector symbolic operators used for Semantic Pointers in the
+        vocabulary.
     """
 
     def __init__(
             self, dimensions, strict=True, max_similarity=0.1, rng=None,
-            name=None):
-        self.algebra = CircularConvolutionAlgebra()
+            name=None, algebra=None):
+        if algebra is None:
+            algebra = CircularConvolutionAlgebra
+        self.algebra = algebra
 
         if not is_integer(dimensions) or dimensions < 1:
             raise ValidationError("dimensions must be a positive integer",

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -85,7 +85,7 @@ class Vocabulary(Mapping):
             self, dimensions, strict=True, max_similarity=0.1, rng=None,
             name=None, algebra=None):
         if algebra is None:
-            algebra = CircularConvolutionAlgebra
+            algebra = CircularConvolutionAlgebra()
         self.algebra = algebra
 
         if not is_integer(dimensions) or dimensions < 1:

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -54,7 +54,7 @@ class Vocabulary(Mapping):
         The random number generator to use to create new vectors.
     name : str
         A name to display in the string representation of this vocabulary.
-    algebra : Algebra, optional
+    algebra : AbstractAlgebra, optional
         Defines the vector symbolic operators used for Semantic Pointers in the
         vocabulary. Defaults to `.CircularConvolutionAlgebra`.
 
@@ -76,7 +76,7 @@ class Vocabulary(Mapping):
     vectors : ndarray
         All of the semantic pointer vectors in a matrix, in the same order
         as in `keys`.
-    algebra : Algebra, optional
+    algebra : AbstractAlgebra, optional
         Defines the vector symbolic operators used for Semantic Pointers in the
         vocabulary.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ source = nengo_spa
 [coverage:report]
 omit =
     */tests/test*
+    nengo_spa/conftest.py
 exclude_lines =
     raise NotImplementedError
 


### PR DESCRIPTION
**Motivation and context:**
This adds the possibility to change the binding (and superposition) operation used by Nengo SPA. It also implements vector-derived transformation binding (VTB) as one alternate binding method.

The specific choice of a superpositiion operation and a binding operation is called an algebra in this PR (as it roughly fits the mathematical definition of an algebra or algebraic structure). Such in algebra is implemented by a class providing pure math implementations of the operations, methods to obtain special elements like the identity, and two methods to provide neural implementations of the two operators.

Each vocabulary (and `SemanticPointer` which might not have a vocabulary) is assigned such an algbra determining the operations used when operands get combined in the SPA syntax (it defaults to `CircularConvolutionAlgebra`). Because operands are required to have the same vocabulary, it is always clear what algebra to use, i.e., there is no situation in which the operands might have different algebras (except for `SemanticPointer` which raises an exception in this case).

Currently there is not way to change the default algebra, but one has to explicitely create a vocabulary with the desired algbra. Not sure whether there should be a way to set this default ...

Closes #69.

**Interactions with other PRs:**
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Tests have been added, updated, etc.
An `algebra` fixture has been added that will parametrize a test to run with both implemented algebras.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
The commits should be self-contained, so that one could go commit by commit. But I revised some things multiple times and the back and forth might not be that helpful. Such it might be better to look at the final diff. There are multiple parts that stand mostly on its own:

* Added matrix multiplication network `nengo_spa/networks/matrix_multiplication.py`.
* Added module `nengo_spa/modules/superposition.py`.
* The interface for algebras `nengo_spa/algebras/base.py`.
* The circular convolution algebra `nengo_spa/algebras/cconv.py`. (Probably best to look at this one first as it uses familiar operations.)
* The VTB algebra `nengo_spa/algebras/vtb.py` with the binding network `nengo_spa/networks/vtb.py`.
* Several smaller changes in `nengo_spa/vocab.py` and `nengo_spa/pointer.py` and some other files to enable the use of algebras.
* All of this is accompanied with changes in the respective test files and documentation.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] Extract the VTB network into its own class.
- [x] Try to cut down on the increased test duration.