### PR TITLE
Fix dot with fixed Semantic Pointer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Release History
   GUI.
   (`#202 <https://github.com/nengo/nengo_spa/pull/202>`_,
   `#184 <https://github.com/nengo/nengo_spa/issues/184>`_)
+- Label the utility nodes for the action selection.
+  (`#202 <https://github.com/nengo/nengo_spa/pull/202>`__)
 
 
 **Changed**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,12 @@ Release History
 - Fix ``nengo_spa.ActionSelection.keys()`` when no named actions have been
   provided.
   (`#210 <https://github.com/nengo/nengo_spa/pull/210>`_)
+- Do not create an unnecessary compare network when computing a dot product
+  with a ``SemanticPointer`` instance.
+  (`#202 <https://github.com/nengo/nengo_spa/pull/202>`__)
+- Handle ``SemanticPointer`` instances correctly as first argument to
+  ``nengo_spa.dot``.
+  (`#202 <https://github.com/nengo/nengo_spa/pull/202>`__)
 
 
 0.5.2 (July 6, 2018)

--- a/nengo_spa/action_selection.py
+++ b/nengo_spa/action_selection.py
@@ -149,10 +149,12 @@ class ActionSelection(Mapping):
 
     def add_action(self, name, *actions):
         assert ActionSelection.active is self
-        utility = input_vocab_registry.declare_connector(
-            nengo.Node(size_in=1), None)
         if name is not None:
             self._name2idx[name] = len(self._actions)
+        else:
+            name = str(len(self._actions))
+        utility = input_vocab_registry.declare_connector(
+            nengo.Node(size_in=1, label="Utility for action " + name), None)
         self._utilities.append(utility)
         self._actions.append(actions)
         RoutedConnection.free_floating.difference_update(actions)

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -5,7 +5,7 @@ from nengo.utils.compat import is_number
 import numpy as np
 
 from nengo_spa.ast.base import infer_types, Node, TypeCheckedBinaryOp
-from nengo_spa.ast.symbolic import FixedScalar, PointerSymbol, Symbol
+from nengo_spa.ast.symbolic import Fixed, FixedScalar, Symbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.types import TAnyVocab, TScalar, TAnyVocabOfDim, TVocabulary
 
@@ -119,7 +119,7 @@ class DynamicNode(Node):
         if self.type == TScalar or other.type == TScalar:
             raise SpaTypeError("Cannot do a dot product with a scalar.")
 
-        if isinstance(other, PointerSymbol):
+        if isinstance(other, Fixed):
             tr = np.atleast_2d(other.evaluate().v)
             return Transformed(self, tr, TScalar)
         else:

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -18,9 +18,6 @@ class SemanticPointer(Fixed):
     ----------
     data : array_like
         The vector constituting the Semantic Pointer.
-    rng : numpy.random.RandomState, optional
-        Random number generator used for random generation of a Semantic
-        Pointer.
     vocab : Vocabulary, optional
         Vocabulary that the Semantic Pointer is considered to be part of.
         Mutually exclusive with the *algebra* argument.
@@ -44,13 +41,10 @@ class SemanticPointer(Fixed):
         Name of the Semantic Pointer.
     """
 
-    def __init__(self, data, rng=None, vocab=None, algebra=None, name=None):
+    def __init__(self, data, vocab=None, algebra=None, name=None):
         super(SemanticPointer, self).__init__(
             TAnyVocab if vocab is None else TVocabulary(vocab))
         self.algebra = self._get_algebra(vocab, algebra)
-
-        if rng is None:
-            rng = np.random
 
         self.v = np.array(data, dtype=float)
         if len(self.v.shape) != 1:

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -265,7 +265,10 @@ class SemanticPointer(Fixed):
         if isinstance(other, Fixed):
             infer_types(self, other)
             other = other.evaluate().v
-        return np.dot(self.v, other)
+        if is_array(other):
+            return np.dot(self.v, other)
+        else:
+            return other.dot(self)
 
     def __matmul__(self, other):
         return self.dot(other)

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -1,6 +1,6 @@
 import nengo
 from nengo.exceptions import ValidationError
-from nengo.utils.compat import is_array, is_number
+from nengo.utils.compat import is_array, is_array_like, is_number
 import numpy as np
 
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
@@ -265,7 +265,7 @@ class SemanticPointer(Fixed):
         if isinstance(other, Fixed):
             infer_types(self, other)
             other = other.evaluate().v
-        if is_array(other):
+        if is_array_like(other):
             return np.dot(self.v, other)
         else:
             return other.dot(self)

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -148,6 +148,9 @@ def test_dot(rng):
     a = SemanticPointer(next(gen)) * 1.1
     b = SemanticPointer(next(gen)) * (-1.5)
     assert np.allclose(a.dot(b), np.dot(a.v, b.v))
+    assert np.allclose(a.dot(b.v), np.dot(a.v, b.v))
+    assert np.allclose(a.dot(list(b.v)), np.dot(a.v, b.v))
+    assert np.allclose(a.dot(tuple(b.v)), np.dot(a.v, b.v))
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="requires Python 3.5")

--- a/nengo_spa/tests/test_vector_generation.py
+++ b/nengo_spa/tests/test_vector_generation.py
@@ -22,9 +22,9 @@ def test_unit_length_pointers(rng):
 def test_unitary_pointers(rng):
     algebra = HrrAlgebra()
     g = UnitaryVectors(64, algebra, rng)
-    a = SemanticPointer(next(g), algebra)
-    b = SemanticPointer(next(g), algebra)
-    c = SemanticPointer(next(g), algebra)
+    a = SemanticPointer(next(g), algebra=algebra)
+    b = SemanticPointer(next(g), algebra=algebra)
+    c = SemanticPointer(next(g), algebra=algebra)
     assert np.allclose(a.compare(c), (a * b).compare(c * b))
 
 


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
Fixes the problem discovered in #202 that a dot product with a fixed `SemanticPointer` instance creates a compare network which is not needed. This ensures that a transform is used instead.

Furthermore, it fixes a problem where `spa.dot(a, b)` would return a NumPy array instead of a scalar or AST node when `a` was a `SemanticPointer`.

Somewhat related to the the confusion in #202 a label is added for the action utility node.

**Interactions with other PRs:**
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Extended tests except for the label of the utility node.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)


**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
