### PR TITLE
Fix CI tests

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -16,7 +16,7 @@ if [[ "$COMMAND" == "install" ]]; then
     if [[ "$SCIPY" == "true" ]]; then
         conda install scipy
     fi
-    pip install 'pytest<4.0' pytest-xdist nengo=="$NENGO"
+    pip install 'pytest<4.0' 'pytest-xdist<1.28' nengo=="$NENGO"
     pip install -e .
 elif [[ "$COMMAND" == "run" ]]; then
     python -c "import numpy; numpy.show_config()"


### PR DESCRIPTION
**Motivation and context:**
Set maximum pytest and xdist versions to avoid the tests failing on CI. Newer pytest versions produce warnings with Nengo 2.8 (i.e. those cannot be fixed in Nengo SPA) and newer xdist versions are incompatible with the chosen pytest version.

**Interactions with other PRs:**
none

**How has this been tested?**
Waited for CI tests to pass.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [n/a] I have run the test suite locally and all tests passed.
