### PR TITLE
Ensure free floating connections are cleared

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ Release History
 
 **Fixed**
 
+- Fixed a bug where an exception within an ``ActionSelection`` block would
+  lead to every subsequent ``ActionSelection`` block to raise an exception.
+  (`#230 <https://github.com/nengo/nengo_spa/issues/230>`__,
+  `#231 <https://github.com/nengo/nengo_spa/pull/231>`__)
 - Nengo SPA is now compatible with pytest 4. Support for earlier versions has
   been dropped.
   (`#227 <https://github.com/nengo/nengo_spa/pull/227>`__)

--- a/nengo_spa/action_selection.py
+++ b/nengo_spa/action_selection.py
@@ -92,6 +92,7 @@ class ActionSelection(Mapping):
         ActionSelection.active = None
         ModuleInput.routed_mode = False
         if exc_type is not None:
+            RoutedConnection.free_floating.clear()
             return
         self._build()
 

--- a/nengo_spa/tests/test_action_selection.py
+++ b/nengo_spa/tests/test_action_selection.py
@@ -390,3 +390,18 @@ def test_action_selection_keys_corner_cases():
         with ActionSelection() as action_sel:
             spa.ifmax(0.)
     assert list(action_sel.keys()) == [0]
+
+
+def test_action_selection_is_side_effect_free_if_exception_is_raised():
+    with spa.Network():
+        state_a = spa.State(32)
+        state_b = spa.State(32)
+        state_c = spa.State(64)
+
+        with pytest.raises(SpaTypeError):
+            with ActionSelection():
+                spa.ifmax(1, state_a >> state_b, state_a >> state_c)
+
+        with ActionSelection():
+            pass
+            # should not raise


### PR DESCRIPTION
**Motivation and context:**
Ensure free floating connections are cleared after leaving ActionSelection block.

Fixes #230.

**Interactions with other PRs:**
none

**How has this been tested?**
added a unit test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
