### PR TITLE
Ensure Nengo 3 compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Miniconda"
     - PYTHON: "C:\\Miniconda36"
     - PYTHON: "C:\\Miniconda36-x64"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
-  - conda install numpy==1.13 matplotlib jupyter pytest pywinpty
+  - conda install numpy==1.16 matplotlib jupyter pytest pywinpty
   - pip install nengo
 
 build: false  # Not a C# project

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install numpy==1.16 matplotlib jupyter pytest pywinpty
-  - pip install nengo
+  - pip install https://github.com/nengo/nengo/archive/master.zip
 
 build: false  # Not a C# project
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -16,7 +16,7 @@ if [[ "$COMMAND" == "install" ]]; then
     if [[ "$SCIPY" == "true" ]]; then
         conda install scipy
     fi
-    pip install 'pytest>=4,<5' pytest-xdist nengo=="$NENGO"
+    pip install 'pytest>=4,<5' pytest-xdist pytest-plt pytest-rng nengo=="$NENGO"
     pip install -e .
 elif [[ "$COMMAND" == "run" ]]; then
     python -c "import numpy; numpy.show_config()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ env:
 matrix:
   include:
     - env: PYTHON="3.7" STATIC="true"
-    - env: PYTHON="2.7" COVERAGE="true"
-    - env: PYTHON="2.7" NUMPY="1.8"  # minimum supported NumPy
-    - env: PYTHON="3.4" NUMPY="1.11"  # 1.12 not packaged for py34 in conda
     - env: PYTHON="3.5" NUMPY="1.15"  # 1.16 not packaged for py35 in conda
     - env: PYTHON="3.6"
     - env: PYTHON="3.7" COVERAGE="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 env:
   global:
     - NENGO="2.7"
-    - NUMPY="1.16"
+    - NUMPY="1.17"
     - SCIPY="true"
     - COVERAGE="false"
     - STATIC="false"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ Release History
 0.6.3 (unreleased)
 ==================
 
+**Changed**
+
+- Ensure compatibility with Nengo 3.
+  (`#225 <https://github.com/nengo/nengo_spa/issues/225>`__,
+  `#233 <https://github.com/nengo/nengo_spa/pull/233>`__)
 
 
 0.6.2 (June 21, 2019)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Release History
    - Fixed
 
 
-0.6.3 (unreleased)
+0.7.0 (unreleased)
 ==================
 
 **Changed**
@@ -28,6 +28,12 @@ Release History
 - Ensure compatibility with Nengo 3.
   (`#225 <https://github.com/nengo/nengo_spa/issues/225>`__,
   `#233 <https://github.com/nengo/nengo_spa/pull/233>`__)
+
+
+**Removed**
+
+- Dropped support for Python 2.7 and 3.4.
+  (`#233 <https://github.com/nengo/nengo_spa/pull/233>`__)
 
 
 0.6.2 (June 21, 2019)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,5 +52,5 @@ Contributor agreement
 ---------------------
 
 We require that all contributions be covered under our contributor assignment
-agreement. Please see `the agreement <https://www.nengo.ai/caa.html>`_
+agreement. Please see `the agreement <https://www.nengo.ai/caa/>`_
 for instructions on how to sign.

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -1,41 +1,16 @@
-import inspect
-import os.path
+try:
+    from pytest_nengo import (  # pylint: disable=unused-import
+        pytest_configure, pytest_runtest_setup)
+except ImportError:
+    import nengo
+    import pytest
 
-from nengo.conftest import (  # pylint: disable=unused-import
-    pytest_configure, pytest_runtest_setup, recorder_dirname, RefSimulator,
-    Simulator, seed, rng)
-from nengo.utils.testing import Plotter
-import pytest
+    @pytest.fixture(scope='session')
+    def Simulator(request):
+        return nengo.Simulator
 
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.algebras.vtb_algebra import VtbAlgebra
-
-
-# Copied from
-# https://github.com/nengo/nengo/blob/dfeb4335e0f8720e1248466719ca08be9a5badfd/nengo/conftest.py
-# which contains fixes for pytest 4 that are not released at the time of
-# writing this. Also, relying on importing this function from Nengo would also
-# prevent us from testing earlier Nengo releases that do not contain the fixes.
-def parametrize_function_name(request, function_name):
-    """Creates a unique name for a test function.
-
-    The unique name accounts for values passed through
-    ``pytest.mark.parametrize``.
-
-    This function is used when naming plots saved through the ``plt`` fixture.
-    """
-    suffixes = []
-    if 'parametrize' in request.keywords:
-        argnames = []
-        for marker in request.keywords.node.iter_markers("parametrize"):
-            argnames.extend([x.strip() for names in marker.args[::2]
-                             for x in names.split(',')])
-        for name in argnames:
-            value = request.getfixturevalue(name)
-            if inspect.isclass(value):
-                value = value.__name__
-            suffixes.append('{}={}'.format(name, value))
-    return '+'.join([function_name] + suffixes)
 
 
 class TestConfig(object):
@@ -53,34 +28,5 @@ class TestConfig(object):
 
 
 def pytest_generate_tests(metafunc):
-    if 'algebra' in metafunc.funcargnames:
+    if 'algebra' in metafunc.fixturenames:
         metafunc.parametrize('algebra', [a for a in TestConfig.algebras])
-
-
-def recorder_dirname_with_algebra(request, name):
-    dirname = recorder_dirname(request, name)
-    if 'algebra' in request.funcargnames:
-        algebra = request.getfixturevalue('algebra')
-        dirname = os.path.join(dirname, algebra.__name__)
-    return dirname
-
-
-@pytest.fixture
-def plt(request):
-    """A pyplot-compatible plotting interface.
-
-    Please use this if your test creates plots.
-
-    This will keep saved plots organized in a simulator-specific folder,
-    with an automatically generated name. savefig() and close() will
-    automatically be called when the test function completes.
-
-    If you need to override the default filename, set `plt.saveas` to
-    the desired filename.
-    """
-    dirname = recorder_dirname_with_algebra(request, 'plots')
-    plotter = Plotter(
-        dirname, request.module.__name__,
-        parametrize_function_name(request, request.function.__name__))
-    request.addfinalizer(lambda: plotter.__exit__(None, None, None))
-    return plotter.__enter__()

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -1,5 +1,5 @@
 import nengo
-from nengo.utils.numpy import rmse
+from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
@@ -43,10 +43,10 @@ def test_run(Simulator, algebra, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    error = rmse(vocab.parse("(B*A).normalized()").v, sim.data[p][-1])
+    error = rms(vocab.parse("(B*A).normalized()").v - sim.data[p][-1])
     assert error < 0.15
 
-    error = rmse(vocab.parse("(A*A).normalized()").v, sim.data[p][100])
+    error = rms(vocab.parse("(A*A).normalized()").v - sim.data[p][100])
     assert error < 0.15
 
 

--- a/nengo_spa/modules/tests/test_superposition.py
+++ b/nengo_spa/modules/tests/test_superposition.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import nengo
-from nengo.utils.numpy import rmse
+from nengo.utils.numpy import rms
 
 import nengo_spa as spa
 from nengo_spa.vocabulary import VocabularyMap
@@ -43,8 +43,8 @@ def test_run(Simulator, algebra, seed):
     with Simulator(model) as sim:
         sim.run(0.2)
 
-    error = rmse(vocab.parse("(B+A).normalized()").v, sim.data[p][-1])
+    error = rms(vocab.parse("(B+A).normalized()").v - sim.data[p][-1])
     assert error < 0.1
 
-    error = rmse(vocab.parse("(A+A).normalized()").v, sim.data[p][100])
+    error = rms(vocab.parse("(A+A).normalized()").v - sim.data[p][100])
     assert error < 0.2

--- a/nengo_spa/networks/matrix_multiplication.py
+++ b/nengo_spa/networks/matrix_multiplication.py
@@ -80,9 +80,11 @@ def MatrixMult(n_neurons, shape_left, shape_right, **kwargs):
             transform_right[c_index][k + j * shape_right[1]] = 1
 
         nengo.Connection(
-            net.input_left, net.C.A, transform=transform_left, synapse=None)
+            net.input_left, net.C.input_a, transform=transform_left,
+            synapse=None)
         nengo.Connection(
-            net.input_right, net.C.B, transform=transform_right, synapse=None)
+            net.input_right, net.C.input_b, transform=transform_right,
+            synapse=None)
 
         # Now do the appropriate summing
         size_output = shape_left[0] * shape_right[1]

--- a/nengo_spa/networks/tests/test_circularconv.py
+++ b/nengo_spa/networks/tests/test_circularconv.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import nengo
-from nengo.utils.numpy import rmse
+from nengo.utils.numpy import rms
 
 import nengo_spa
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
@@ -64,8 +64,8 @@ def test_input_magnitude(Simulator, seed, rng, dims=16, magnitude=10):
     with Simulator(model) as sim:
         sim.run(0.01)
 
-    error = rmse(result, sim.data[res_p][-1]) / (magnitude ** 2)
-    error_bad = rmse(result, sim.data[res_p_bad][-1]) / (magnitude ** 2)
+    error = rms(result - sim.data[res_p][-1]) / (magnitude ** 2)
+    error_bad = rms(result - sim.data[res_p_bad][-1]) / (magnitude ** 2)
 
     assert error < 0.2
     assert error_bad > 0.1
@@ -92,6 +92,6 @@ def test_neural_accuracy(Simulator, seed, rng, dims, neurons_per_product=128):
     with Simulator(model) as sim:
         sim.run(0.01)
 
-    error = rmse(result, sim.data[res_p][-1])
+    error = rms(result - sim.data[res_p][-1])
 
     assert error < 0.2

--- a/nengo_spa/networks/tests/test_selection.py
+++ b/nengo_spa/networks/tests/test_selection.py
@@ -77,8 +77,8 @@ def test_thresholding_array(Simulator, plt, seed):
 
     assert np.all(sim.data[out_p][t > 0.15, :2] > 0.9)
     assert np.all(sim.data[out_p][t > 0.15, 2:] < 0.001)
-    assert_allclose(sim.data[thresholded_p][t > 0.15, 0], 0.6, atol=0.05)
-    assert_allclose(sim.data[thresholded_p][t > 0.15, 1], 0.3, atol=0.05)
+    assert_allclose(sim.data[thresholded_p][t > 0.15, 0], 0.6, atol=0.06)
+    assert_allclose(sim.data[thresholded_p][t > 0.15, 1], 0.3, atol=0.06)
     assert np.all(sim.data[thresholded_p][t > 0.15, 2:] < 0.001)
 
 

--- a/nengo_spa/tests/test_examples.py
+++ b/nengo_spa/tests/test_examples.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import _pytest.capture
 
-from nengo.utils.ipython import read_nb
+from nbformat import read as read_nb
 from nengo.utils.stdlib import execfile
 
 # Monkeypatch _pytest.capture.DontReadFromInput
@@ -33,7 +33,7 @@ all_examples, slow_examples, fast_examples = [], [], []
 
 def load_example(example):
     with open(example + '.ipynb', 'r') as f:
-        nb = read_nb(f)
+        nb = read_nb(f, 4)
     return nb
 
 

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -156,7 +156,7 @@ def test_casting_vocabs(d1, d2, method, lookup, Simulator, plt, rng):
     assert np.mean(spa.similarity(sim.data[p][t], v)) > 0.8
 
 
-def test_copy_spa(RefSimulator):
+def test_copy_spa(Simulator):
     with spa.Network() as original:
         original.state = spa.State(16)
         spa.sym.A >> original.state
@@ -164,7 +164,7 @@ def test_copy_spa(RefSimulator):
     cp = original.copy()
 
     # Check that it still builds.
-    with RefSimulator(cp):
+    with Simulator(cp):
         pass
 
 

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -283,7 +283,8 @@ def test_identity(algebra):
         Identity(64, algebra=algebra).v, algebra.identity_element(64))
 
 
-def test_absorbing_element(algebra):
+def test_absorbing_element(algebra, plt):
+    plt.plot([0, 1], [0, 1])
     try:
         assert np.allclose(
             AbsorbingElement(64, algebra=algebra).v,

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ ignore = E123,E133,E226,E241,E242,E501,E731,F401,W503
 max-complexity = 10
 
 [tool:pytest]
-addopts = -p nengo.tests.options
 norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots
 markers =
     example: Mark a test as an example.
@@ -51,3 +50,6 @@ filterwarnings =
     ignore:IPython.core.inputsplitter:DeprecationWarning
     ignore:Matplotlib is currently using agg
     ignore:Using or importing the ABCs:DeprecationWarning:pyparsing
+    ignore:Using or importing the ABCs:DeprecationWarning:nbformat
+    ignore:Using or importing the ABCs:DeprecationWarning:nengo
+    ignore:The SafeConfigParser class has been renamed:DeprecationWarning:nengo

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ optional_requires = [
 tests_require = [
     "jupyter",
     "matplotlib>=2.0",
-    "pytest>=4.0,<5"
+    "nbformat",
+    "pytest>=4.0,<5",
+    "pytest-plt",
+    "pytest-rng"
 ]
 
 setup(
@@ -61,7 +64,7 @@ setup(
         "numpy>=1.8",
     ],
     install_requires = [
-        "nengo>=2.7,<3.0",
+        "nengo>=2.7,<4.0",
         "numpy>=1.8",
     ],
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -81,10 +81,9 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: Free for non-commercial use",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
 )


### PR DESCRIPTION
**Motivation and context:**
This mostly introduces some changes to the test environment
utilizing pytest-plt and pytest-rng. On older Nengo versions
these fixtures will be imported as from Nengo itself as before.
However, we don't support the test command line options
on Nengo versions prior to 3 anymore. All tests (including tests
marked as slow) will run on these versions, but no plots will be
produced. On Nengo 3 these command line options are supported as
before.

Besides that this adds some irrelevant warnings to the ignore list
and fixes an instance where deprecated network inputs have been
used.

Closes #225.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

**Interactions with other PRs:**
none

**How has this been tested?**
Ran the tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
