### PR TITLE
Do not set default labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,16 @@ Release History
 - Ensure compatibility with Nengo 3.
   (`#225 <https://github.com/nengo/nengo_spa/issues/225>`__,
   `#233 <https://github.com/nengo/nengo_spa/pull/233>`__)
+- Modules and networks no longer set a default label. This will give
+  more useful labels by default in Nengo GUI (assuming the latest dev
+  version).
+  (`#234 <https://github.com/nengo/nengo_spa/issues/234>`__,
+  `#235 <https://github.com/nengo/nengo_spa/pull/235>`__)
+- All networks have been converted to classes. This will give
+  more useful labels by default in Nengo GUI (assuming the latest dev
+  version).
+  (`#234 <https://github.com/nengo/nengo_spa/issues/234>`__,
+  `#235 <https://github.com/nengo/nengo_spa/pull/235>`__)
 
 
 **Removed**

--- a/nengo_spa/modules/associative_memory.py
+++ b/nengo_spa/modules/associative_memory.py
@@ -62,7 +62,7 @@ class AssociativeMemory(Network):
 
     def __init__(
             self, selection_net, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label="Associative memory", seed=None,
+            n_neurons=50, label=None, seed=None,
             add_to_container=None, vocabs=None, **selection_net_kwargs):
         super(AssociativeMemory, self).__init__(
             label=label, seed=seed, add_to_container=add_to_container,
@@ -158,7 +158,7 @@ class IAAssocMem(AssociativeMemory):
     """
     def __init__(
             self, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label="IA associative memory", seed=None,
+            n_neurons=50, label=None, seed=None,
             add_to_container=None, vocabs=None, **selection_net_kwargs):
         super(IAAssocMem, self).__init__(
             selection_net=IA,
@@ -177,7 +177,7 @@ class ThresholdingAssocMem(AssociativeMemory):
     """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label="Thresholding associative memory", seed=None,
+            n_neurons=50, label=None, seed=None,
             add_to_container=None, vocabs=None, **selection_net_kwargs):
         selection_net_kwargs['threshold'] = threshold
         super(ThresholdingAssocMem, self).__init__(
@@ -195,7 +195,7 @@ class WTAAssocMem(AssociativeMemory):
     """
     def __init__(
             self, threshold, input_vocab, output_vocab=None, mapping=None,
-            n_neurons=50, label="WTA associative memory", seed=None,
+            n_neurons=50, label=None, seed=None,
             add_to_container=None, vocabs=None, **selection_net_kwargs):
         selection_net_kwargs['threshold'] = threshold
         super(WTAAssocMem, self).__init__(

--- a/nengo_spa/modules/basalganglia.py
+++ b/nengo_spa/modules/basalganglia.py
@@ -144,7 +144,6 @@ class BasalGanglia(Network):
             self, action_count, n_neurons_per_ensemble=Default,
             output_weight=Default, input_bias=Default, ampa_synapse=Default,
             gaba_synapse=Default, **kwargs):
-        kwargs.setdefault('label', "Basal ganglia")
         super(BasalGanglia, self).__init__(**kwargs)
 
         self.action_count = action_count

--- a/nengo_spa/modules/bind.py
+++ b/nengo_spa/modules/bind.py
@@ -39,7 +39,6 @@ class Bind(Network):
 
     def __init__(self, vocab=Default, neurons_per_dimension=Default,
                  unbind_left=Default, unbind_right=Default, **kwargs):
-        kwargs.setdefault('label', "Bind")
         super(Bind, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/compare.py
+++ b/nengo_spa/modules/compare.py
@@ -34,7 +34,6 @@ class Compare(Network):
         'neurons_per_dimension', default=200, low=1, readonly=True)
 
     def __init__(self, vocab=Default, neurons_per_dimension=Default, **kwargs):
-        kwargs.setdefault('label', "Compare")
         super(Compare, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/product.py
+++ b/nengo_spa/modules/product.py
@@ -27,7 +27,6 @@ class Product(Network):
     n_neurons = IntParam('n_neurons', default=200, low=1, readonly=True)
 
     def __init__(self, n_neurons=Default, **kwargs):
-        kwargs.setdefault('label', "Product")
         super(Product, self).__init__(**kwargs)
 
         self.n_neurons = n_neurons

--- a/nengo_spa/modules/scalar.py
+++ b/nengo_spa/modules/scalar.py
@@ -25,7 +25,6 @@ class Scalar(Network):
     n_neurons = IntParam('n_neurons', default=50, low=1, readonly=True)
 
     def __init__(self, n_neurons=Default, **kwargs):
-        kwargs.setdefault('label', "Scalar")
         super(Scalar, self).__init__(**kwargs)
 
         self.n_neurons = n_neurons

--- a/nengo_spa/modules/state.py
+++ b/nengo_spa/modules/state.py
@@ -63,7 +63,6 @@ class State(Network):
                  neurons_per_dimension=Default, feedback=Default,
                  represent_cc_identity=Default,
                  feedback_synapse=Default, **kwargs):
-        kwargs.setdefault('label', "State")
         super(State, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/superposition.py
+++ b/nengo_spa/modules/superposition.py
@@ -34,7 +34,6 @@ class Superposition(Network):
 
     def __init__(self, n_inputs, vocab=Default, neurons_per_dimension=Default,
                  **kwargs):
-        kwargs.setdefault('label', "Superposition")
         super(Superposition, self).__init__(**kwargs)
 
         self.vocab = vocab

--- a/nengo_spa/modules/thalamus.py
+++ b/nengo_spa/modules/thalamus.py
@@ -84,7 +84,6 @@ class Thalamus(Network):
                  synapse_bg=Default, neurons_channel_dim=Default,
                  synapse_channel=Default, neurons_gate=Default,
                  threshold_gate=Default, synapse_to_gate=Default, **kwargs):
-        kwargs.setdefault('label', "Thalamus")
         super(Thalamus, self).__init__(**kwargs)
 
         self.action_count = action_count

--- a/nengo_spa/modules/transcode.py
+++ b/nengo_spa/modules/transcode.py
@@ -169,7 +169,6 @@ class Transcode(Network):
     def __init__(
             self, function=Default, input_vocab=Default, output_vocab=Default,
             size_in=Default, size_out=Default, **kwargs):
-        kwargs.setdefault('label', "Transcode")
         super(Transcode, self).__init__(**kwargs)
 
         # Vocabs need to be set before function which accesses vocab for

--- a/nengo_spa/networks/identity_ensemble_array.py
+++ b/nengo_spa/networks/identity_ensemble_array.py
@@ -27,13 +27,12 @@ class IdentityEnsembleArray(nengo.Network):
     **kwargs : dict
         Keyword arguments to pass through to the `nengo.Network` constructor.
 
-    Returns
-    -------
-    nengo.Network
-        Network with attributes:
-
-        * **input** (`nengo.Node`): Input node.
-        * **output** (`nengo.Node`): Output node.
+    Attributes
+    ----------
+    input : nengo.Node
+        Input node.
+    output : nengo.Node
+        Output node.
     """
     def __init__(
             self, neurons_per_dimension, dimensions, subdimensions, **kwargs):

--- a/nengo_spa/networks/matrix_multiplication.py
+++ b/nengo_spa/networks/matrix_multiplication.py
@@ -2,7 +2,7 @@ import nengo
 import numpy as np
 
 
-def MatrixMult(n_neurons, shape_left, shape_right, **kwargs):
+class MatrixMult(nengo.Network):
     """Computes the matrix product A*B.
 
     Both matrices need to be two dimensional.
@@ -25,78 +25,80 @@ def MatrixMult(n_neurons, shape_left, shape_right, **kwargs):
     **kwargs : dict
         Keyword arguments to pass through to the `nengo.Network` constructor.
 
-    Returns
-    -------
-    net : Network
-        The newly built matrix multiplication network with attributes:
-
-         * **input_left** (`nengo.Node`): The left matrix (A) to multiply.
-         * **input_right** (`nengo.Node`): The left matrix (A) to multiply.
-         * **C** (`nengo.networks.Product`): The product network doing the
-           matrix multiplication.
-         * **output** (`nengo.node`): The resulting matrix result.
+    Attributes
+    ----------
+    input_left : nengo.Node
+        The left matrix (A) to multiply.
+    input_right : nengo.Node
+        The left matrix (A) to multiply.
+    C : nengo.networks.Product
+        The product network doing the matrix multiplication.
+    output : nengo.node
+        The resulting matrix result.
     """
+    def __init__(self, n_neurons, shape_left, shape_right, **kwargs):
+        if len(shape_left) != 2:
+            raise ValueError(
+                "Shape {} is not two dimensional.".format(shape_left))
+        if len(shape_right) != 2:
+            raise ValueError(
+                "Shape {} is not two dimensional.".format(shape_right))
+        if shape_left[1] != shape_right[0]:
+            raise ValueError(
+                "Matrix dimensions {} and  {} are incompatible".format(
+                    shape_left, shape_right))
 
-    if len(shape_left) != 2:
-        raise ValueError("Shape {} is not two dimensional.".format(shape_left))
-    if len(shape_right) != 2:
-        raise ValueError(
-            "Shape {} is not two dimensional.".format(shape_right))
-    if shape_left[1] != shape_right[0]:
-        raise ValueError(
-            "Matrix dimensions {} and  {} are incompatible".format(
-                shape_left, shape_right))
+        super().__init__(**kwargs)
 
-    size_left = np.prod(shape_left)
-    size_right = np.prod(shape_right)
+        size_left = np.prod(shape_left)
+        size_right = np.prod(shape_right)
 
-    with nengo.Network(**kwargs) as net:
-        net.input_left = nengo.Node(size_in=size_left)
-        net.input_right = nengo.Node(size_in=size_right)
+        with self:
+            self.input_left = nengo.Node(size_in=size_left)
+            self.input_right = nengo.Node(size_in=size_right)
 
-        # The C matrix is composed of populations that each contain
-        # one element of A (left) and one element of B (right).
-        # These elements will be multiplied together in the next step.
-        size_c = size_left * shape_right[1]
-        net.C = nengo.networks.Product(n_neurons, size_c)
+            # The C matrix is composed of populations that each contain
+            # one element of A (left) and one element of B (right).
+            # These elements will be multiplied together in the next step.
+            size_c = size_left * shape_right[1]
+            self.C = nengo.networks.Product(n_neurons, size_c)
 
-        # Determine the transformation matrices to get the correct pairwise
-        # products computed.  This looks a bit like black magic but if
-        # you manually try multiplying two matrices together, you can see
-        # the underlying pattern.  Basically, we need to build up D1*D2*D3
-        # pairs of numbers in C to compute the product of.  If i,j,k are the
-        # indexes into the D1*D2*D3 products, we want to compute the product
-        # of element (i,j) in A with the element (j,k) in B.  The index in
-        # A of (i,j) is j+i*D2 and the index in B of (j,k) is k+j*D3.
-        # The index in C is j+k*D2+i*D2*D3, multiplied by 2 since there are
-        # two values per ensemble.  We add 1 to the B index so it goes into
-        # the second value in the ensemble.
-        transform_left = np.zeros((size_c, size_left))
-        transform_right = np.zeros((size_c, size_right))
+            # Determine the transformation matrices to get the correct pairwise
+            # products computed.  This looks a bit like black magic but if
+            # you manually try multiplying two matrices together, you can see
+            # the underlying pattern.  Basically, we need to build up D1*D2*D3
+            # pairs of numbers in C to compute the product of.  If i,j,k are
+            # the indexes into the D1*D2*D3 products, we want to compute the
+            # product # of element (i,j) in A with the element (j,k) in B.  The
+            # index in # A of (i,j) is j+i*D2 and the index in B of (j,k) is
+            # k+j*D3. The index in C is j+k*D2+i*D2*D3, multiplied by 2 since
+            # there are # two values per ensemble.  We add 1 to the B index so
+            # it goes into # the second value in the ensemble.
+            transform_left = np.zeros((size_c, size_left))
+            transform_right = np.zeros((size_c, size_right))
 
-        for i, j, k in np.ndindex(shape_left[0], *shape_right):
-            c_index = (j + k * shape_right[0] + i * size_right)
-            transform_left[c_index][j + i * shape_right[0]] = 1
-            transform_right[c_index][k + j * shape_right[1]] = 1
+            for i, j, k in np.ndindex(shape_left[0], *shape_right):
+                c_index = (j + k * shape_right[0] + i * size_right)
+                transform_left[c_index][j + i * shape_right[0]] = 1
+                transform_right[c_index][k + j * shape_right[1]] = 1
 
-        nengo.Connection(
-            net.input_left, net.C.input_a, transform=transform_left,
-            synapse=None)
-        nengo.Connection(
-            net.input_right, net.C.input_b, transform=transform_right,
-            synapse=None)
+            nengo.Connection(
+                self.input_left, self.C.input_a, transform=transform_left,
+                synapse=None)
+            nengo.Connection(
+                self.input_right, self.C.input_b, transform=transform_right,
+                synapse=None)
 
-        # Now do the appropriate summing
-        size_output = shape_left[0] * shape_right[1]
-        net.output = nengo.Node(size_in=size_output)
+            # Now do the appropriate summing
+            size_output = shape_left[0] * shape_right[1]
+            self.output = nengo.Node(size_in=size_output)
 
-        # The mapping for this transformation is much easier, since we want to
-        # combine D2 pairs of elements (we sum D2 products together)
-        transform_c = np.zeros((size_output, size_c))
-        for i in range(size_c):
-            transform_c[i // shape_right[0]][i] = 1
+            # The mapping for this transformation is much easier, since we want
+            # to combine D2 pairs of elements (we sum D2 products together)
+            transform_c = np.zeros((size_output, size_c))
+            for i in range(size_c):
+                transform_c[i // shape_right[0]][i] = 1
 
-        nengo.Connection(
-            net.C.output, net.output, transform=transform_c, synapse=None)
-
-    return net
+            nengo.Connection(
+                self.C.output, self.output, transform=transform_c,
+                synapse=None)

--- a/nengo_spa/networks/selection.py
+++ b/nengo_spa/networks/selection.py
@@ -3,11 +3,7 @@ import nengo
 import numpy as np
 
 
-def IA(
-        n_neurons, n_ensembles, accum_threshold=0.8, accum_neuron_ratio=0.7,
-        accum_timescale=0.2, feedback_timescale=0.005,
-        accum_synapse=0.1, ff_synapse=0.005,
-        intercept_width=0.15, radius=1., **kwargs):
+class IA(nengo.Network):
     """Independent accumulator (IA) winner-take-all (WTA) network.
 
     This is a two-layered network. The first layer consists of independent
@@ -51,17 +47,18 @@ def IA(
     **kwargs : dict
         Keyword arguments passed on to `nengo.Network`.
 
-    Returns
-    -------
-    nengo.Network
-        Network with attributes:
-
-        * **input** (`nengo.Node`): The inputs to the network.
-        * **input_reset** (`nengo.Node`): Input to reset the accumulators.
-        * **output** (`nengo.Node`): The outputs of the network.
-        * **accumulators** (`nengo.Thresholding`): The layer 1 accumulators.
-        * **thresholding** (`nengo.Thresholding`): The layer 2 thresholding
-          ensembles.
+    Attributes
+    ----------
+    input : nengo.Node
+        The inputs to the network.
+    input_reset : nengo.Node
+        Input to reset the accumulators.
+    output : nengo.Node
+        The outputs of the network.
+    accumulators : nengo.Thresholding
+        The layer 1 accumulators.
+    thresholding : nengo.Thresholding
+        The layer 2 thresholding ensembles.
 
     References
     ----------
@@ -70,48 +67,51 @@ def IA(
        In Proceedings of the 39th Annual Conference of the Cognitive Science
        Society. London, UK, 2017. Cognitive Science Society.
     """
-    n_accum_neurons = int(accum_neuron_ratio * n_neurons)
-    n_thresholding_neurons = n_neurons - n_accum_neurons
+    def __init__(self, n_neurons, n_ensembles, accum_threshold=0.8,
+                 accum_neuron_ratio=0.7, accum_timescale=0.2,
+                 feedback_timescale=0.005, accum_synapse=0.1, ff_synapse=0.005,
+                 intercept_width=0.15, radius=1., **kwargs):
+        super().__init__(**kwargs)
 
-    bar_beta = 1. + radius * feedback_timescale / accum_timescale
-    feedback_tr = (
-        np.eye(n_ensembles) - bar_beta * (1. - np.eye(n_ensembles))
-        / feedback_timescale)
+        n_accum_neurons = int(accum_neuron_ratio * n_neurons)
+        n_thresholding_neurons = n_neurons - n_accum_neurons
 
-    with nengo.Network(**kwargs) as net:
-        net.accumulators = Thresholding(
-            n_accum_neurons, n_ensembles, threshold=0.,
-            intercept_width=intercept_width, radius=radius)
-        net.thresholding = Thresholding(
-            n_thresholding_neurons, n_ensembles, threshold=accum_threshold,
-            intercept_width=intercept_width, radius=radius,
-            function=lambda x: x > accum_threshold)
+        bar_beta = 1. + radius * feedback_timescale / accum_timescale
+        feedback_tr = (
+            np.eye(n_ensembles) - bar_beta * (1. - np.eye(n_ensembles))
+            / feedback_timescale)
 
-        nengo.Connection(
-            net.accumulators.output, net.accumulators.input,
-            synapse=accum_synapse)
-        nengo.Connection(
-            net.accumulators.output, net.thresholding.input,
-            synapse=ff_synapse)
-        nengo.Connection(
-            net.thresholding.output, net.accumulators.input,
-            synapse=accum_synapse, transform=accum_synapse * feedback_tr)
+        with self:
+            self.accumulators = Thresholding(
+                n_accum_neurons, n_ensembles, threshold=0.,
+                intercept_width=intercept_width, radius=radius)
+            self.thresholding = Thresholding(
+                n_thresholding_neurons, n_ensembles, threshold=accum_threshold,
+                intercept_width=intercept_width, radius=radius,
+                function=lambda x: x > accum_threshold)
 
-        net.input_reset = nengo.Node(size_in=1)
-        nengo.Connection(
-            net.input_reset, net.accumulators.input, synapse=None,
-            transform=-radius * np.ones((n_ensembles, 1)) / accum_synapse)
+            nengo.Connection(
+                self.accumulators.output, self.accumulators.input,
+                synapse=accum_synapse)
+            nengo.Connection(
+                self.accumulators.output, self.thresholding.input,
+                synapse=ff_synapse)
+            nengo.Connection(
+                self.thresholding.output, self.accumulators.input,
+                synapse=accum_synapse, transform=accum_synapse * feedback_tr)
 
-        net.input = nengo.Node(size_in=n_ensembles)
-        nengo.Connection(net.input, net.accumulators.input, synapse=None,
-                         transform=1. / accum_timescale)
-        net.output = net.thresholding.output
-    return net
+            self.input_reset = nengo.Node(size_in=1)
+            nengo.Connection(
+                self.input_reset, self.accumulators.input, synapse=None,
+                transform=-radius * np.ones((n_ensembles, 1)) / accum_synapse)
+
+            self.input = nengo.Node(size_in=n_ensembles)
+            nengo.Connection(self.input, self.accumulators.input, synapse=None,
+                             transform=1. / accum_timescale)
+            self.output = self.thresholding.output
 
 
-def Thresholding(
-        n_neurons, n_ensembles, threshold, intercept_width=0.15, function=None,
-        radius=1., **kwargs):
+class Thresholding(nengo.Network):
     """Array of thresholding ensembles.
 
     All inputs below the threshold will produce an output of 0, whereas inputs
@@ -134,39 +134,40 @@ def Thresholding(
     **kwargs : dict
         Keyword arguments passed on to `nengo.Network`.
 
-    Returns
-    -------
-    nengo.Network
-        Network with attributes:
-
-        * **input** (`nengo.Node`): The inputs to the network.
-        * **output** (`nengo.Node`): The outputs of the network.
-        * **thresholded** (`nengo.Node`): The raw thresholded value (before
-          applying *function* or correcting for the shift produced by the
-          thresholding).
+    Attributes
+    ----------
+    input : nengo.Node
+        The inputs to the network.
+    output : nengo.Node
+        The outputs of the network.
+    thresholded : nengo.Node
+        The raw thresholded value (before applying *function* or correcting for
+        the shift produced by the thresholding).
     """
-    with nengo.Network(**kwargs) as net:
-        with nengo.presets.ThresholdingEnsembles(
-                0., intercept_width, radius=radius):
-            net.thresholding = nengo.networks.EnsembleArray(
-                n_neurons, n_ensembles)
+    def __init__(self, n_neurons, n_ensembles, threshold, intercept_width=0.15,
+                 function=None, radius=1., **kwargs):
+        super().__init__(**kwargs)
 
-        net.bias = nengo.Node(1.)
-        nengo.Connection(net.bias, net.thresholding.input,
-                         transform=-threshold * np.ones((n_ensembles, 1)))
+        with self:
+            with nengo.presets.ThresholdingEnsembles(
+                    0., intercept_width, radius=radius):
+                self.thresholding = nengo.networks.EnsembleArray(
+                    n_neurons, n_ensembles)
 
-        net.input = net.thresholding.input
-        net.thresholded = net.thresholding.output
+            self.bias = nengo.Node(1.)
+            nengo.Connection(self.bias, self.thresholding.input,
+                             transform=-threshold * np.ones((n_ensembles, 1)))
 
-        if function is None:
-            function = lambda x: x
-        function = lambda x, function=function: function(x + threshold)
-        net.output = net.thresholding.add_output('function', function)
-    return net
+            self.input = self.thresholding.input
+            self.thresholded = self.thresholding.output
+
+            if function is None:
+                function = lambda x: x
+            function = lambda x, function=function: function(x + threshold)
+            self.output = self.thresholding.add_output('function', function)
 
 
-def WTA(n_neurons, n_ensembles, inhibit_scale=1.0, inhibit_synapse=0.005,
-        **kwargs):
+class WTA(Thresholding):
     """Winner-take-all (WTA) network with lateral inhibition.
 
     Parameters
@@ -182,21 +183,22 @@ def WTA(n_neurons, n_ensembles, inhibit_scale=1.0, inhibit_synapse=0.005,
     **kwargs : dict
         Keyword arguments passed on to `Thresholding`.
 
-    Returns
-    -------
-    nengo.Network
-        Network with attributes:
-
-        * **input** (`nengo.Node`): The inputs to the network.
-        * **output** (`nengo.Node`): The outputs of the network.
-        * **thresholded** (`nengo.Node`): The raw thresholded value (before
-          applying *function* or correcting for the shift produced by the
-          thresholding).
+    Attributes
+    ----------
+    input : nengo.Node
+        The inputs to the network.
+    output : nengo.Node
+        The outputs of the network.
+    thresholded : nengo.Node
+        The raw thresholded value (before applying *function* or correcting for
+        the shift produced by the thresholding).
     """
-    net = Thresholding(n_neurons, n_ensembles, **kwargs)
-    with net:
-        nengo.Connection(
-            net.thresholded, net.input,
-            transform=inhibit_scale * (np.eye(n_ensembles) - 1.),
-            synapse=inhibit_synapse)
-    return net
+    def __init__(self, n_neurons, n_ensembles, inhibit_scale=1.0,
+                 inhibit_synapse=0.005, **kwargs):
+        super().__init__(n_neurons, n_ensembles, **kwargs)
+
+        with self:
+            nengo.Connection(
+                self.thresholded, self.input,
+                transform=inhibit_scale * (np.eye(n_ensembles) - 1.),
+                synapse=inhibit_synapse)

--- a/nengo_spa/networks/vtb.py
+++ b/nengo_spa/networks/vtb.py
@@ -32,8 +32,7 @@ def swapping_matrix(dimensions):
     return m
 
 
-def VTB(n_neurons, dimensions, unbind_left=False, unbind_right=False,
-        **kwargs):
+class VTB(nengo.Network):
     r"""Compute vector-derived transformation binding (VTB).
 
     VTB uses elementwise addition for superposition. The binding operation
@@ -85,66 +84,70 @@ def VTB(n_neurons, dimensions, unbind_left=False, unbind_right=False,
     **kwargs : dict
         Keyword arguments to pass through to the `nengo.Network` constructor.
 
-    Returns
-    -------
-    nengo.Network
-        The newly built product network with attributes:
-
-         * **input_left** (`nengo.Node`): The left operand vector to be bound.
-         * **input_right** (`nengo.Node`): The right operand vector to be
-           bound.
-         * **mat** (`nengo.Node`): Representation of the matrix :math:`V_y'`.
-         * **vec** (`nengo.Node`): Representation of the vector :math:`y`.
-         * **matmuls** (`list`): Matrix multiplication networks.
-         * **output** (`nengo.Node`): The resulting bound vector.
+    Attributes
+    ----------
+    input_left : nengo.Node
+        The left operand vector to be bound.
+    input_right : nengo.Node
+        The right operand vector to be bound.
+    mat : nengo.Node
+        Representation of the matrix :math:`V_y'`.
+    vec : nengo.Node
+        Representation of the vector :math:`y`.
+    matmuls : list
+        Matrix multiplication networks.
+    output : nengo.Node
+        The resulting bound vector.
     """
-    sub_d = calc_sub_d(dimensions)
+    def __init__(self, n_neurons, dimensions, unbind_left=False,
+                 unbind_right=False, **kwargs):
+        super().__init__(**kwargs)
 
-    shape_left = (sub_d, sub_d)
-    shape_right = (sub_d, 1)
+        sub_d = calc_sub_d(dimensions)
 
-    with nengo.Network(**kwargs) as net:
-        net.input_left = nengo.Node(size_in=dimensions)
-        net.input_right = nengo.Node(size_in=dimensions)
-        net.output = nengo.Node(size_in=dimensions)
+        shape_left = (sub_d, sub_d)
+        shape_right = (sub_d, 1)
 
-        net.mat = nengo.Node(size_in=dimensions)
-        net.vec = nengo.Node(size_in=dimensions)
+        with self:
+            self.input_left = nengo.Node(size_in=dimensions)
+            self.input_right = nengo.Node(size_in=dimensions)
+            self.output = nengo.Node(size_in=dimensions)
 
-        if unbind_left and unbind_right:
-            raise ValueError("Cannot unbind both sides at the same time.")
-        elif unbind_left:
-            nengo.Connection(
-                net.input_left, net.mat,
-                transform=inversion_matrix(dimensions), synapse=None)
-            nengo.Connection(
-                net.input_right, net.vec,
-                transform=swapping_matrix(dimensions), synapse=None)
-        else:
-            nengo.Connection(net.input_left, net.vec, synapse=None)
-            if unbind_right:
-                tr = inversion_matrix(dimensions)
+            self.mat = nengo.Node(size_in=dimensions)
+            self.vec = nengo.Node(size_in=dimensions)
+
+            if unbind_left and unbind_right:
+                raise ValueError("Cannot unbind both sides at the same time.")
+            elif unbind_left:
+                nengo.Connection(
+                    self.input_left, self.mat,
+                    transform=inversion_matrix(dimensions), synapse=None)
+                nengo.Connection(
+                    self.input_right, self.vec,
+                    transform=swapping_matrix(dimensions), synapse=None)
             else:
-                tr = 1.
-            nengo.Connection(
-                net.input_right, net.mat, transform=tr, synapse=None)
+                nengo.Connection(self.input_left, self.vec, synapse=None)
+                if unbind_right:
+                    tr = inversion_matrix(dimensions)
+                else:
+                    tr = 1.
+                nengo.Connection(
+                    self.input_right, self.mat, transform=tr, synapse=None)
 
-        with nengo.Config(nengo.Ensemble) as cfg:
-            cfg[nengo.Ensemble].intercepts = CosineSimilarity(
-                dimensions + 2)
-            cfg[nengo.Ensemble].eval_points = CosineSimilarity(
-                dimensions + 2)
-            net.matmuls = [
-                MatrixMult(n_neurons, shape_left, shape_right)
-                for i in range(sub_d)]
+            with nengo.Config(nengo.Ensemble) as cfg:
+                cfg[nengo.Ensemble].intercepts = CosineSimilarity(
+                    dimensions + 2)
+                cfg[nengo.Ensemble].eval_points = CosineSimilarity(
+                    dimensions + 2)
+                self.matmuls = [
+                    MatrixMult(n_neurons, shape_left, shape_right)
+                    for i in range(sub_d)]
 
-        for i in range(sub_d):
-            mm = net.matmuls[i]
-            sl = slice(i * sub_d, (i + 1) * sub_d)
-            nengo.Connection(net.mat, mm.input_left, synapse=None)
-            nengo.Connection(net.vec[sl], mm.input_right, synapse=None)
-            nengo.Connection(
-                mm.output, net.output[sl], transform=np.sqrt(sub_d),
-                synapse=None)
-
-    return net
+            for i in range(sub_d):
+                mm = self.matmuls[i]
+                sl = slice(i * sub_d, (i + 1) * sub_d)
+                nengo.Connection(self.mat, mm.input_left, synapse=None)
+                nengo.Connection(self.vec[sl], mm.input_right, synapse=None)
+                nengo.Connection(
+                    mm.output, self.output[sl], transform=np.sqrt(sub_d),
+                    synapse=None)


### PR DESCRIPTION
**Motivation and context:**
Given the nengo/nengo-gui#1002 has been merged, not setting any default labels will give more informative labels in the Nengo GUI. This also converts all networks to classes to be more consistent.

**Interactions with other PRs:**
none

**How has this been tested?**
existing tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

Most lines did just change in indentation (due to __init__ being nested in the class) and have `net` renamed to `self`.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
