### PR TITLE
Ensure SP algebra matches vocab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,14 +68,15 @@ jobs:
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: jgosmann
         password: $PYPI_TOKEN
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,14 @@ Release History
 1.0.2 (unreleased)
 ==================
 
+**Changed**
+
+- Raise an exception when a Semantic Pointer is added to a vocabulary with a
+  differing algebra.
+  (`#239 <https://github.com/nengo/nengo_spa/issues/239>`__,
+  `#240 <https://github.com/nengo/nengo_spa/pull/240>`__)
+
+
 
 1.0.1 (December 14, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,11 +20,15 @@ Release History
    - Fixed
 
 
-1.0.2 (unreleased)
+1.1.0 (unreleased)
 ==================
 
 **Changed**
 
+- Make ``AbstractAlgebra`` an actual abstract base class (using ``ABCMeta`` as
+  meta-class). While still supported, this deprecates pure duck-typing for
+  algebras.
+  (`#240 <https://github.com/nengo/nengo_spa/pull/240>`__)
 - Raise an exception when a Semantic Pointer is added to a vocabulary with a
   differing algebra.
   (`#239 <https://github.com/nengo/nengo_spa/issues/239>`__,

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -31,6 +31,6 @@ from nengo_spa.vector_generation import (
 from nengo_spa.vocabulary import Vocabulary
 
 
-__copyright__ = "2013-2018, Applied Brain Research"
+__copyright__ = "2013-2020, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
 __version__ = version.version

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -1,4 +1,32 @@
-class AbstractAlgebra(object):
+from abc import ABCMeta
+import warnings
+
+
+class _DuckTypedABCMeta(ABCMeta):
+    def __instancecheck__(cls, instance):
+        if super().__instancecheck__(instance):
+            return True
+
+        for member in dir(cls):
+            if member.startswith("_"):
+                continue
+            if not hasattr(instance, member) or not hasattr(
+                getattr(instance, member), "__self__"
+            ):
+                return False
+        warnings.warn(
+            DeprecationWarning(
+                "Please do not rely on pure duck-typing for {clsname}. "
+                "Explicitly register your class {userclass} as a virtual subclass "
+                "of {clsname} or derive from it.".format(
+                    clsname=cls.__name__, userclass=instance.__class__.__name__
+                )
+            )
+        )
+        return True
+
+
+class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
     """Abstract base class for algebras.
 
     Custom algebras can be defined by implementing the interface of this

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.vector_generation import UnitLengthVectors
 
 
@@ -90,3 +91,50 @@ def test_zero_element(algebra, rng):
     p = algebra.zero_element(16)
     assert np.all(p == 0.0)
     assert np.allclose(algebra.bind(a, p), 0.0)
+
+
+def test_isinstance_check(algebra):
+    assert isinstance(algebra, AbstractAlgebra)
+
+
+class DummyAlgebra:
+    def is_valid_dimensionality(self, d):
+        pass
+
+    def make_unitary(self, v):
+        pass
+
+    def superpose(self, a, b):
+        pass
+
+    def bind(self, a, b):
+        pass
+
+    def invert(self, v):
+        pass
+
+    def get_binding_matrix(self, v, swap_inputs=False):
+        pass
+
+    def get_inversion_matrix(self, d):
+        pass
+
+    def implement_superposition(self, n_neurons_per_d, d, n):
+        pass
+
+    def implement_binding(self, n_neurons_per_d, d, unbind_left, unbind_right):
+        pass
+
+    def absorbing_element(self, d):
+        pass
+
+    def identity_element(self, d):
+        pass
+
+    def zero_element(self, d):
+        pass
+
+
+@pytest.mark.filterwarnings("ignore:.*do not rely on pure duck-typing")
+def test_isinstance_ducktyping_check():
+    assert isinstance(DummyAlgebra(), AbstractAlgebra)

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -2,6 +2,7 @@ import nengo
 from nengo.exceptions import ValidationError
 import numpy as np
 
+from nengo_spa.algebras.base import AbstractAlgebra
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.ast.base import Fixed, infer_types, TypeCheckedBinaryOp
 from nengo_spa.typechecks import is_array, is_array_like, is_number
@@ -63,6 +64,10 @@ class SemanticPointer(Fixed):
                 algebra = vocab.algebra
         elif vocab is not None and vocab.algebra is not algebra:
             raise ValueError("vocab and algebra argument are mutually exclusive")
+        if not isinstance(algebra, AbstractAlgebra):
+            raise ValidationError(
+                "'algebra' must be an instance of AbstractAlgebra", "algebra", algebra
+            )
         return algebra
 
     def _get_unary_name(self, op):

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -8,6 +8,7 @@ import pytest
 
 import nengo_spa as spa
 from nengo_spa.algebras.base import AbstractAlgebra
+from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.semantic_pointer import AbsorbingElement, Identity, SemanticPointer, Zero
@@ -273,6 +274,13 @@ def test_incompatible_algebra(op):
     b = SemanticPointer(next(gen), algebra=AbstractAlgebra())  # noqa: F841
     with pytest.raises(TypeError):
         eval("a" + op + "b")
+
+
+def test_invalid_algebra():
+    gen = UnitLengthVectors(32)
+    with pytest.raises(ValidationError, match="AbstractAlgebra"):
+        SemanticPointer(next(gen), algebra=HrrAlgebra)
+    SemanticPointer(next(gen), algebra=HrrAlgebra())
 
 
 def test_identity(algebra):

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -6,7 +6,8 @@ import numpy as np
 from numpy.testing import assert_equal
 import pytest
 
-from nengo_spa import Vocabulary
+from nengo_spa import SemanticPointer, Vocabulary
+from nengo_spa.algebras import HrrAlgebra, VtbAlgebra
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.vector_generation import AxisAlignedVectors
 from nengo_spa.vocabulary import (
@@ -23,6 +24,23 @@ def test_add(rng):
     v.add("B", [4, 5, 6])
     v.add("C", [7, 8, 9])
     assert np.allclose(v.vectors, [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+
+def test_add_raises_exception_for_algebra_mismatch():
+    v = Vocabulary(4, algebra=HrrAlgebra())
+    with pytest.raises(ValidationError, match="different vocabulary or algebra"):
+        v.add("V", SemanticPointer(np.ones(4), algebra=VtbAlgebra()))
+    v.add("V", SemanticPointer(np.ones(4), algebra=VtbAlgebra()).reinterpret(v))
+
+
+def test_added_algebra_match(rng):
+    v = Vocabulary(4, algebra=VtbAlgebra())
+    sp = v.create_pointer()
+    assert sp.algebra is VtbAlgebra()
+    v.add("V", sp)
+    assert v["V"].vocab is v
+    assert v["V"].algebra is VtbAlgebra()
+    assert v["V"].name == "V"
 
 
 def test_populate(rng):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Mixing algebras is not supported without explicit casts. Thus raise an exception when this is tried.

SemanticPointe.reinterpret can be used to add the pointer anyways.

Fixes #239.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
unit test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.