### PR TITLE
Support fractional binding in algebras (spatial semantic pointers)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,8 +178,7 @@ Release History
 **Removed**
 
 - Removed ``nengo_spa.networks.circularconvolution.circconv`` because
-  ``nengo_spa.algebras.CircularConvolutionAlgebra`` provides the same
-  functionality.
+  ``nengo_spa.algebras.HrrAlgebra`` provides the same functionality.
   (`#198 <https://github.com/nengo/nengo_spa/pull/198>`__)
 - The ``SemanticPointer`` class does no longer accept a single integer as
   dimensionality to create a random vector. Use the new generators in

--- a/docs/user-guide/algebras.rst
+++ b/docs/user-guide/algebras.rst
@@ -2,7 +2,7 @@ Algebras
 --------
 
 Nengo SPA uses elementwise addition for superposition and circular convolution
-for binding (`.CircularConvolutionAlgebra`) by default. However, other choices are
+for binding (`.HrrAlgebra`) by default. However, other choices are
 viable. In Nengo SPA we call such a specific choice of such operators an
 *algebra*. It is easy to change the algebra that is used by Nengo SPA as it is
 tied to the vocabulary. To use a different algebra, it suffices to manually

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -104,6 +104,38 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
+    def fractional_bind(self, v, exponent):
+        """Returns *v* bound with itself *exponent* times.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to exponentiate.
+        exponent : float
+            The exponent of the (potentially fractional) power.
+
+        Returns
+        -------
+        (d,) ndarray
+            *v* to the power of *exponent*.
+        """
+        raise NotImplementedError()
+
+    def make_nondegenerate(self, v):
+        """Returns a nondegenerate vector based on the vector *v*.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to base nondegenerate vector on.
+
+        Returns
+        -------
+        ndarray
+            Nondegenerate vector.
+        """
+        raise NotImplementedError()
+
     def invert(self, v):
         """Invert vector *v*.
 

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -110,6 +110,12 @@ class DummyAlgebra:
     def bind(self, a, b):
         pass
 
+    def fractional_bind(self, v, exponent):
+        pass
+
+    def make_nondegenerate(self, v):
+        pass
+
     def invert(self, v):
         pass
 

--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -41,7 +41,15 @@ class VtbAlgebra(AbstractAlgebra):
 
     The VTB binding operation is neither associative nor commutative.
 
-    Publications with further information are forthcoming.
+    Fractional binding for this algebra is currently an experimental feature.
+
+    More information on VTB as a type of vector symbolic architecture can be
+    found in [gosmann2019]_.
+
+    .. [gosmann2019] Gosmann, J. and Eliasmith, C. Vector-derived
+       transformation binding: an improved binding operation for deep
+       symbol-like processing in neural networks. Neural Computation,
+       31(5):849-869, 2019.
     """
 
     _instance = None

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -25,7 +25,7 @@ class SemanticPointer(Fixed):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     name : str, optional
         A name for the Semantic Pointer.
@@ -425,7 +425,7 @@ class Identity(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     """
 
@@ -452,7 +452,7 @@ class AbsorbingElement(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     """
 
@@ -475,7 +475,7 @@ class Zero(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     """
 

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -13,7 +13,8 @@ class SemanticPointer(Fixed):
     """A Semantic Pointer, based on Holographic Reduced Representations.
 
     Operators are overloaded so that ``+`` and ``-`` are addition,
-    ``*`` is circular convolution, and ``~`` is the inversion operator.
+    ``*`` is circular convolution, ``~`` is the inversion operator,
+    and ``**`` is fractional binding (see [komer2019]_).
 
     Parameters
     ----------
@@ -40,6 +41,11 @@ class SemanticPointer(Fixed):
         The vocabulary the this Semantic Pointer is considered to be part of.
     name : str or None
         Name of the Semantic Pointer.
+
+    .. [komer2019] Komer, B., Stewart, T.C., Voelker, A.R. and Eliasmith, C.
+       A neural representation of continuous space using fractional binding.
+       Proceedings of the 41st Annual Meeting of the Cognitive Science
+       Society. 2019.
     """
 
     def __init__(self, data, vocab=None, algebra=None, name=None):

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -132,6 +132,26 @@ class SemanticPointer(Fixed):
             name=self._get_method_name("unitary"),
         )
 
+    def nondegenerate(self):
+        """Make the Semantic Pointer nondegenerate and return as a new object.
+
+        The original object is not modified.
+
+        A degenerate Semantic Pointer is one that cannot be fractionally bound
+        using an arbitrary exponent in an unambiguous manner.
+        Otherwise the Semantic Pointer is said to be nondegenerate.
+
+        A unitary Semantic Pointer that is made nondegenerate will still be
+        unitary, and vice-versa. However, the Semantic Pointer can become
+        degenerate after certain operations (this depends on the algebra).
+        """
+        return SemanticPointer(
+            self.algebra.make_nondegenerate(self.v),
+            vocab=self.vocab,
+            algebra=self.algebra,
+            name=self._get_method_name("nondegenerate"),
+        )
+
     def copy(self):
         """Return another semantic pointer with the same data."""
         return SemanticPointer(
@@ -233,6 +253,17 @@ class SemanticPointer(Fixed):
                 return self._bind(other, swap=swap)
         else:
             return NotImplemented
+
+    def __pow__(self, exponent):
+        """Bind the Semantic Pointer with itself *exponent* times."""
+        if not is_number(exponent):
+            return NotImplemented
+        return SemanticPointer(
+            data=self.algebra.fractional_bind(self.v, exponent),
+            vocab=self.vocab,
+            algebra=self.algebra,
+            name=self._get_binary_name(exponent, "**"),
+        )
 
     def __invert__(self):
         """Return a reorganized vector that acts as an inverse for convolution.

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -451,10 +451,3 @@ def test_nondegenerate_vtb(d, rng):
     assert np.allclose((x ** 3).v, (x * x * x).v)
     assert np.allclose((x ** 3).v, (identity * x).v)
     assert np.allclose((x ** 3).v, (x * identity).v)
-
-    # satisfies translational properties as long as the intermediate results
-    # are allowed to be complex
-    x_complex = SemanticPointer(v, algebra=algebra, dtype=np.complex128).nondegenerate()
-
-    assert np.any(np.iscomplex((x_complex ** 0.5).v))
-    assert np.allclose((x_complex ** (-0.5) * x_complex ** 2.5).v, (x * x).v)

--- a/nengo_spa/vocabulary.py
+++ b/nengo_spa/vocabulary.py
@@ -59,7 +59,7 @@ class Vocabulary(Mapping):
         A name to display in the string representation of this vocabulary.
     algebra : AbstractAlgebra, optional
         Defines the vector symbolic operators used for Semantic Pointers in the
-        vocabulary. Defaults to `.CircularConvolutionAlgebra`.
+        vocabulary. Defaults to `.HrrAlgebra`.
 
     Attributes
     ----------


### PR DESCRIPTION
**Motivation and context:**
Fractional binding supports encoding and decoding of continuous quantities, which is useful when representing things like spatial maps ([Komer et al., 2019](http://compneuro.uwaterloo.ca/files/publications/komer.2019.pdf)). This is proposed as a core `nengo-spa` change since it is natural to have the pow (`**`) operator implement fractional binding.

In addition, a `dtype` is added to the `SemanticPointer` class to enable experimentation with other datatypes including complex semantic pointers. Feedback is welcome on whether or not this addition is useful or necessary. Likewise, fractional binding with the VTB algebra is experimental and the implementations may be subject to change. 

**How has this been tested?**
Certain properties for both HRR and VTB are tested for when they hold or don't hold.

**How long should this take to review?**
- Lengthy (more than 150 lines changed or changes are complicated)

**Where should a reviewer start?**
Can start by looking at the algebra files to see how the methods are implemented. Then the unit tests to see how properties are validated.

**Types of changes:**
- New feature (non-breaking change which adds functionality)
- Breaking change (new methods for the abstract algebra class)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
 - [ ] Include a changelog entry.
 - [x] Respond to early feedback about what it useful to include in this PR.
 - [ ] Add a neural implementation for fractional binding.

**Moved to #245:**
 - [x] ~Ensure that dtype is included everywhere (e.g., vocabulary?)~
 - [x] ~Unit test complex dtypes with all operations.~