### PR TITLE
Add dtype to SemanticPointer and fix repr

### DIFF
--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -308,9 +308,8 @@ def test_name():
 
     assert str(a) == "SemanticPointer<a>"
     assert repr(a) == (
-        "SemanticPointer({!r}, vocab={!r}, algebra={!r}, name={!r}".format(
-            a.v, a.vocab, a.algebra, a.name
-        )
+        "SemanticPointer({!r}, vocab={!r}, algebra={!r}, "
+        "name={!r}, dtype={!r})".format(a.v, a.vocab, a.algebra, a.name, a.dtype,)
     )
 
     assert (-a).name == "-(a)"


### PR DESCRIPTION
**Motivation and context:**
This is an experimental feature request (split off from #243 and rebased onto master), that allows one to experiment with other data types for semantic pointers, such as `np.complex64`.

Full support is not provided. The intended scope is for offline algebraic manipulation of SPs. In the future, one might wish to support complex types in the neural implementations as well.

**Interactions with other PRs:**
Assuming #243 is merged first, then this would need to be rebased such that `dtype` also passed into the new methods for SP fractional binding. Also changes may be needed to allow `fractional_bind` to return a complex SP if the datatype is complex.

**How has this been tested?**
Unit tests pass, but new unit tests are needed (see 'Still to do').

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- New feature (non-breaking change which adds functionality)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [ ] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
 - [ ] Unit test algebraic manipulation of complex SPs
 - [ ] Check all of the places where semantic pointers are created (e.g., `vocabulary.py`)
 - [ ] Add changelog entry