### PR TITLE
Truncate semantic pointer names to 1 KB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,10 @@ Release History
 - ``SemanticPointer.translate`` and ``PointerSymbol.translate`` now use the ``keys``
   argument; previously, this argument was mistakenly ignored.
   (`#248 <https://github.com/nengo/nengo_spa/pull/248>`__)
+- Fixed an issue where the names of iteratively generated semantic pointers
+  could grow exponentially in length, by truncating them at 1 KB.
+  (`#244 <https://github.com/nengo/nengo_spa/issues/244>`__,
+  `#246 <https://github.com/nengo/nengo_spa/pull/246>`__)
 
 
 1.0.1 (December 14, 2019)

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -29,7 +29,7 @@ Licensed code
 Nengo SPA imports several open source libraries.
 
 * `NumPy <http://www.numpy.org/>`_ - Used under
-  `BSD license <http://www.numpy.org/license.html>`__
+  `BSD license <http://www.numpy.org/doc/stable/license.html>`__
 * `Sphinx <http://www.sphinx-doc.org/en/master>`_ - Used under
   `BSD license <https://bitbucket.org/birkenfeld/sphinx/src/be5bd373a1a47fb68d70523b6e980e654e070e9f/LICENSE?at=default>`__
 * `nbsphinx <https://github.com/spatialaudio/nbsphinx>`_ - Used under

--- a/docs/user-guide/spa-intro.rst
+++ b/docs/user-guide/spa-intro.rst
@@ -126,7 +126,7 @@ example of an SPA to date.
    nonlinear dynamical arm model). Central information manipulation depends on
    syntaictic structure for several tasks. Control is largely captured by the
    basal ganglia aciton selection elements. Memory and learning take place in
-   both basal ganglia and contex. The model itself consists of just under
+   both basal ganglia and cortex. The model itself consists of just under
    a million spiking neurons.
 
 Let us consider how the model would perform a single run of one of the cognitive

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -42,6 +42,8 @@ class SemanticPointer(Fixed):
         Name of the Semantic Pointer.
     """
 
+    MAX_NAME = 1024
+
     def __init__(self, data, vocab=None, algebra=None, name=None):
         super(SemanticPointer, self).__init__(
             TAnyVocab if vocab is None else TVocabulary(vocab)
@@ -54,6 +56,9 @@ class SemanticPointer(Fixed):
         self.v.setflags(write=False)
 
         self.vocab = vocab
+
+        if name is not None and len(name) > self.MAX_NAME:
+            name = "%s..." % (name[: self.MAX_NAME - 3])
         self.name = name
 
     def _get_algebra(cls, vocab, algebra):

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -324,6 +324,12 @@ def test_name():
     assert (a + unnamed).name is None
     assert (a * unnamed).name is None
 
+    # check that names that blow up exponentially in length are truncated
+    for i in range(10):
+        a += a * b
+    assert len(a.name) == a.MAX_NAME
+    assert a.name.endswith("...")
+
 
 def test_translate(rng):
     v1 = spa.Vocabulary(16, pointer_gen=rng)


### PR DESCRIPTION
**Motivation and context:**
Fixes #244. 1 KB was chosen somewhat arbitrarily, but it seems long enough to capture the majority of use cases where someone might want to read the name, while being a cheap amount of memory relative to the resource requirements of the semantic pointer itself and how it will be used.

I considered adding a warning, but it didn't seem important enough to let the user know (the fact that the name is being truncated seems inconsequential for most users)?

**How has this been tested?**
Added a unit test similar to the reproducing example from #244.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.