### PR TITLE
nondegenerate fractional vtb binding

### DIFF
--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -112,7 +112,7 @@ class VtbAlgebra(AbstractAlgebra):
 
         sub_d = self._get_sub_d(len(v))
         sub_m = fractional_matrix_power(
-            np.sqrt(sub_d) * v.reshape((sub_d, sub_d)), exponent
+            np.sqrt(sub_d) * v.reshape((sub_d, sub_d)).T, exponent
         )
         m = np.kron(np.eye(sub_d), sub_m)
         # more efficient than the equivalent:
@@ -139,7 +139,7 @@ class VtbAlgebra(AbstractAlgebra):
 
     def get_binding_matrix(self, v, swap_inputs=False):
         sub_d = self._get_sub_d(len(v))
-        m = np.sqrt(sub_d) * np.kron(np.eye(sub_d), v.reshape((sub_d, sub_d)))
+        m = np.sqrt(sub_d) * np.kron(np.eye(sub_d), v.reshape((sub_d, sub_d)).T)
         if swap_inputs:
             m = np.dot(self.get_swapping_matrix(len(v)), m)
         return m

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -441,25 +441,31 @@ def test_nondegenerate_vtb(d, rng):
     # nondegenerate VTB vectors are unitary
     assert np.allclose(algebra.make_unitary(x.v), x.v)
 
-    # binding on top of the identity produces consistent exponent properties
-    assert np.allclose((x ** 1).v, (identity * x).v)
-    assert np.allclose((x ** 2).v, ((identity * x) * x).v)
-    assert np.allclose((x ** 3).v, (((identity * x) * x) * x).v)
+    # power of 0 gives the identity
+    assert np.allclose((x ** 0).v, identity.v)
 
-    assert np.allclose((identity * (x ** 2.3)).v, ((identity * (x ** 1.1)) * (x ** 1.2)).v)
-    assert np.allclose((identity * ~(x ** 2.3)).v, ((identity * ~(x ** 1.1)) * ~(x ** 1.2)).v)
-    assert np.allclose((identity * (x ** -.1)).v, ((identity * (x ** 1.1)) * ~(x ** 1.2)).v)
+    # integer powers, positive and negative
+    assert np.allclose((x ** 1).v, x.v)
+    assert np.allclose((x ** 2).v, (x * x).v)
+    assert np.allclose((x ** 3).v, (((x) * x) * x).v)
+    assert np.allclose((x ** -1).v, (~x).v)
+    assert np.allclose((x ** -2).v, (~x * ~x).v)
+    assert np.allclose((x ** -3).v, (((~x) * ~x) * ~x).v)
 
-    # replacing 'bind' with 'inverse and bind' is required when not binding on top of the identity
-    assert np.allclose((x ** 2.3).v, ((x ** 1.1) * ~(x ** 1.2)).v)
-    assert np.allclose((x ** -2.3).v, ((x ** -1.1) * ~(x ** -1.2)).v)
-    assert np.allclose((x ** 0.7).v, ((x ** -1.5) * ~(x ** 2.2)).v)
-    assert np.allclose((x ** -1.3).v, ((x ** -1.5) * ~(x ** 0.2)).v)
-    assert np.allclose((x ** 2.8).v, (((x ** 1.7) * ~(x ** -0.4)) * ~(x ** 1.5)).v)
+    # fractional powers, positive and negative
+    assert np.allclose((x ** 2.3).v, ((x ** 1.1) * (x ** 1.2)).v)
+    assert np.allclose((x ** -2.3).v, ((x ** -1.1) * (x ** -1.2)).v)
+    assert np.allclose((x ** 0.7).v, ((x ** -1.5) * (x ** 2.2)).v)
+    assert np.allclose((x ** -1.3).v, ((x ** -1.5) * (x ** 0.2)).v)
+    assert np.allclose((x ** 2.8).v, (((x ** 1.7) * (x ** -0.4)) * (x ** 1.5)).v)
+
+    # adding of exponents in general
+    a, b, c = 10 * rng.rand(3) - 5  # [-5, 5]
+    assert np.allclose((x ** a * x ** b * x ** c).v, (x ** (a + b + c)).v)
 
     # repeated fractional binds do not decay the dot product
     step = x ** 0.1
     pt = step
     for _ in range(1, 100):
-        pt = pt *~ step
+        pt = pt * step
     assert(np.allclose(np.dot(pt.v, (x ** 10).v), 1))


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Expanding tests for a future version of non-degenerate VTB for fractional binding.
Currently 50% of unitary vectors are non-degenerate (corresponding to unitary vectors that form matrices with a positive determinant). Using this space instead of the householder matrix approach will permit more useful properties.
Modified `make_nondegenerate` to return a unitary vector with a positive determinant.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->

#243 

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)
- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
