### PR TITLE
Support NumPy scalars; further division support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,9 +25,10 @@ Release History
 
 **Added**
 
-- Support division of ``SemanticPointer`` with constant scalars.
+- Support division with constant scalars.
   (`#249 <https://github.com/nengo/nengo_spa/issues/249>`__,
-  `#253 <https://github.com/nengo/nengo_spa/pull/253>`__)
+  `#253 <https://github.com/nengo/nengo_spa/pull/253>`__,
+  `#257 <https://github.com/nengo/nengo_spa/pull/257>`__)
 
 **Changed**
 
@@ -52,6 +53,10 @@ Release History
   could grow exponentially in length, by truncating them at 1 KB.
   (`#244 <https://github.com/nengo/nengo_spa/issues/244>`__,
   `#246 <https://github.com/nengo/nengo_spa/pull/246>`__)
+- Allow NumPy scalars in place of Python scalars for binary operations on
+  `SemanticPointer` instances.
+  (`#250 <https://github.com/nengo/nengo_spa/issues/250>`__,
+  `#257 <https://github.com/nengo/nengo_spa/pull/257>`__)
 
 
 1.0.1 (December 14, 2019)

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -115,6 +115,13 @@ class DynamicNode(Node):
             return self._mul_with_dynamic(other, swap_inputs=True)
 
     @binary_node_op
+    def __truediv__(self, other):
+        if isinstance(other, FixedScalar):
+            return self._mul_with_fixed(FixedScalar(1.0 / other.value))
+        else:
+            return NotImplemented
+
+    @binary_node_op
     def dot(self, other):
         type_ = infer_types(self, other)
 

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -114,6 +114,11 @@ class PointerSymbol(Symbol):
         type_ = infer_types(self, other)
         return PointerSymbol(other.expr + "*" + self.expr, type_)
 
+    @symbolic_op
+    def __truediv__(self, other):
+        type_ = infer_types(self, other)
+        return PointerSymbol(self.expr + "/" + other.expr, type_)
+
     def dot(self, other):
         other = as_symbolic_node(other)
         if not isinstance(other, PointerSymbol):

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -70,6 +70,24 @@ def test_binary_operation_on_modules(Simulator, algebra, op, suffix, seed, rng):
     )
 
 
+@pytest.mark.parametrize("suffix", ["", ".output"])
+def test_division_with_fixed(Simulator, suffix, seed, rng):
+    vocab = spa.Vocabulary(16, pointer_gen=rng)
+    vocab.populate("A")
+
+    with spa.Network(seed=seed) as model:
+        a = spa.Transcode("A", output_vocab=vocab)  # noqa: F841
+        x = eval("a" + suffix + "/ 2")
+        p = nengo.Probe(x.construct(), synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.3)
+
+    assert_sp_close(
+        sim.trange(), sim.data[p], vocab.parse("0.5 * A"), skip=0.2, atol=0.3
+    )
+
+
 @pytest.mark.parametrize("op", ["+", "-", "*"])
 @pytest.mark.parametrize("order", ["AB", "BA"])
 def test_binary_operation_on_modules_with_pointer_symbol(

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -90,6 +90,17 @@ def test_multiply_fixed_scalar_and_pointer_symbol(scalar, rng):
     assert_equal(node.output, vocab.parse("2 * A").v)
 
 
+@pytest.mark.parametrize("scalar", [2, np.float64(2)])
+def test_divide_pointer_symbol_by_fixed_scalar(scalar, rng):
+    vocab = spa.Vocabulary(16, pointer_gen=rng)
+    vocab.populate("A")
+
+    with spa.Network():
+        x = PointerSymbol("A", TVocabulary(vocab)) / scalar
+        node = x.construct()
+    assert_equal(node.output, vocab.parse("0.5 * A").v)
+
+
 def test_fixed_dot(rng):
     vocab = spa.Vocabulary(16, pointer_gen=rng)
     vocab.populate("A; B")

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -79,12 +79,13 @@ def test_additive_op_fixed_scalar_and_pointer_symbol(op, rng):
             eval("2" + op + "PointerSymbol('A')")
 
 
-def test_multiply_fixed_scalar_and_pointer_symbol(rng):
+@pytest.mark.parametrize("scalar", [2, np.float64(2)])
+def test_multiply_fixed_scalar_and_pointer_symbol(scalar, rng):
     vocab = spa.Vocabulary(16, pointer_gen=rng)
     vocab.populate("A")
 
     with spa.Network():
-        x = 2 * PointerSymbol("A", TVocabulary(vocab))
+        x = scalar * PointerSymbol("A", TVocabulary(vocab))
         node = x.construct()
     assert_equal(node.output, vocab.parse("2 * A").v)
 

--- a/nengo_spa/connectors.py
+++ b/nengo_spa/connectors.py
@@ -165,6 +165,7 @@ class SpaOperatorMixin:
     __rsub__ = __define_binary_op.__func__("__rsub__")
     __mul__ = __define_binary_op.__func__("__mul__")
     __rmul__ = __define_binary_op.__func__("__rmul__")
+    __truediv__ = __define_binary_op.__func__("__truediv__")
     __matmul__ = __define_binary_op.__func__("__matmul__")
     __rmatmul__ = __define_binary_op.__func__("__rmatmul__")
 

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -215,16 +215,16 @@ class SemanticPointer(Fixed):
         return self._mul(other, swap=True)
 
     def _mul(self, other, swap=False):
-        if is_array(other):
-            raise TypeError(
-                "Multiplication of Semantic Pointers with arrays in not allowed."
-            )
-        elif is_number(other):
+        if is_number(other):
             return SemanticPointer(
                 data=self.v * other,
                 vocab=self.vocab,
                 algebra=self.algebra,
                 name=self._get_binary_name(other, "*", swap),
+            )
+        elif is_array(other):
+            raise TypeError(
+                "Multiplication of Semantic Pointers with arrays in not allowed."
             )
         elif isinstance(other, Fixed):
             if other.type == TScalar:
@@ -240,9 +240,7 @@ class SemanticPointer(Fixed):
             return NotImplemented
 
     def __truediv__(self, other):
-        if is_array(other):
-            raise TypeError("Division of Semantic Pointers with arrays is not allowed.")
-        elif is_number(other):
+        if is_number(other):
             if other == 0:
                 raise ZeroDivisionError("Semantic Pointer division by zero")
             return SemanticPointer(
@@ -251,6 +249,8 @@ class SemanticPointer(Fixed):
                 algebra=self.algebra,
                 name=self._get_binary_name(other, "/"),
             )
+        elif is_array(other):
+            raise TypeError("Division of Semantic Pointers with arrays is not allowed.")
         else:
             return NotImplemented
 

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -124,6 +124,10 @@ def test_multiply(rng):
     assert np.allclose((0 * a).v, np.zeros(50))
     assert np.allclose((1 * a).v, a.v)
 
+    numpy_scalar = np.float64(5.7)
+    assert np.allclose((numpy_scalar * a).v, a.v * numpy_scalar)
+    assert np.allclose((a * numpy_scalar).v, a.v * numpy_scalar)
+
     with pytest.raises(Exception):
         a * None
     with pytest.raises(Exception):
@@ -137,6 +141,7 @@ def test_divide(rng):
 
     assert np.allclose((a / 5).v, a.v / 5)
     assert np.allclose((a / 5.7).v, a.v / 5.7)
+    assert np.allclose((a / np.float64(5.7)).v, a.v / 5.7)
     assert np.allclose((a / 1.0).v, a.v)
 
     with pytest.raises(ZeroDivisionError):


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
* This adds support for NumPy scalars in binary operations with `SemanticPointer`. Maybe slightly confusingly both `is_array` and `is_number` are true for NumPy scalars and thus evaluation order of these functions matters.
* While implementing this, I noticed that operations on the AST (that is on modules, symbolic Semantic Pointer expression, and the like) should also support NumPy scalars and division (which was implemented in #254).
  * I added a test for the NumPy scalars.
  * I added a test and the implementation for the division operator.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Added and existing unit tests.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
