### PR TITLE
Fix SPA sequence example

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Release History
   `SemanticPointer` instances.
   (`#250 <https://github.com/nengo/nengo_spa/issues/250>`__,
   `#257 <https://github.com/nengo/nengo_spa/pull/257>`__)
+- The SPA sequence example was not working properly due to a missing connection.
+  (`#258 <https://github.com/nengo/nengo_spa/issues/258>`__,
+  `#259 <https://github.com/nengo/nengo_spa/pull/259>`__)
+
 
 
 1.0.1 (December 14, 2019)

--- a/docs/examples/spa-sequence.ipynb
+++ b/docs/examples/spa-sequence.ipynb
@@ -71,6 +71,8 @@
     "    # Specify the modules to be used\n",
     "    stimulus = spa.Transcode(start, output_vocab=dimensions)\n",
     "    cortex = spa.State(dimensions)\n",
+    "    stimulus >> cortex  # sets initial state for model\n",
+    "\n",
     "    # Specify the action mapping\n",
     "    with spa.ActionSelection() as action_sel:\n",
     "        spa.ifmax(\"A to B\",\n",


### PR DESCRIPTION
The stimulus wasn't connected to the state being sequenced, and so it would randomly break depending on whether the initial state was close enough to some vector in the vocabulary.

**Motivation and context:**
Fixes #258.

**How has this been tested?**
![spa-sequence](https://user-images.githubusercontent.com/5420057/85327907-c10de580-b49d-11ea-9159-704b0163e269.png)

Ran it locally and tried out a bunch of different seeds and longer simulation times. It always seems to do the right thing now.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [x] I have read the **CONTRIBUTING.rst** document.
- [N/A] I have updated the documentation accordingly.
- [x] (added by Jan) I have included a changelog entry.
- [N/A] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
