### PR TITLE
Add dependency version constraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ markers =
 filterwarnings =
     ignore::ImportWarning
     ignore:(Buffer|Memory):DeprecationWarning
+    ignore:IPython.core.inputsplitter is deprecated:DeprecationWarning
     ignore:Skipping some optimization steps
     ignore:SciPy is not installed
     ignore:numpy.(dtype|ufunc) size changed

--- a/setup.py
+++ b/setup.py
@@ -30,20 +30,21 @@ version_module = imp.load_source(
 )
 testing = "test" in sys.argv or "pytest" in sys.argv
 
+numpy = "numpy>=1.8"
 docs_require = [
-    "jupyter_client",
-    "sphinx",
-    "nbsphinx",
-    "nengo_sphinx_theme",
+    "jupyter_client>=5.3.4",
+    "sphinx>=2.2.1",
+    "nbsphinx>=0.5.0",
+    "nengo_sphinx_theme>=1.2.0",
 ]
-optional_requires = ["scipy"]
+optional_requires = ["scipy>=1.4.1"]
 tests_require = [
-    "jupyter",
+    "jupyter>=1.0.0",
     "matplotlib>=2.0",
-    "nbformat",
+    "nbformat>=5.0.7",
     "pytest>=3.6",
-    "pytest-plt",
-    "pytest-rng",
+    "pytest-plt>=1.0.1",
+    "pytest-rng>=1.0.0",
 ]
 
 setup(
@@ -59,8 +60,8 @@ setup(
     long_description=read("README.rst", "CHANGES.rst"),
     zip_safe=True,
     include_package_data=True,
-    setup_requires=["pytest-runner"] if testing else [] + ["numpy>=1.8",],
-    install_requires=["nengo>=2.7,<4", "numpy>=1.8",],
+    setup_requires=["pytest-runner>=5.2"] if testing else [] + [numpy,],
+    install_requires=["nengo>=2.7", numpy,],
     extras_require={
         "all": docs_require + optional_requires + tests_require,
         "docs": docs_require,


### PR DESCRIPTION
**Motivation and context:**
Add version constraint to all dependencies to prevent things from breaking randomly (as long as dependencies follow Semantic Versioning), especially in CI builds. Also, allow pytest 6 to fix incompatibility with pytest-xdist 2 in the CI builds.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
~This supersedes commit 51bf91b5d686851954d37da8ef64038283f86d57 from PR #263.~

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Existing tests and building documentation with minimum versions of dependencies and maximum available versions ~satisfying the constraints~.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
