### PR TITLE
Support to differentiate the sidedness of algebra special elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       - provider: pypi
         server: https://test.pypi.org/legacy/
         user: __token__
-        password: $PYPI_TOKEN
+        password: $PYPI_TEST_TOKEN
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,25 @@ Release History
    - Fixed
 
 
-1.1.2 (unreleased)
+1.2.0 (unreleased)
 ==================
+
+**Added**
+
+- Differentiation between left, right, and two-sided special elements (identity,
+  zero, absorbing element) of an algebra.
+  (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
+
+**Changed**
+
+- Creating special elements (identity, zero, absorbing element) of the
+  ``VtbAlgebra`` without ``sidedness`` argument has been deprecated because
+  these are only right-sided special element. Add the
+  ``sidedness=ElementSidedness.RIGHT`` argument to update your code.
+  (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
+- The ``~`` operator has been deprecated for the ``VtbAlgebra``. Use the
+  ``rinv()`` method instead.
+  (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
 
 
 1.1.1 (November 3, 2020)
@@ -33,7 +50,6 @@ Release History
   ``(sym.A + sym.B) * sym.C`` will be evaluated correctly now.
   (`#267 <https://github.com/nengo/nengo_spa/issues/267>`__,
   `#268 <https://github.com/nengo/nengo_spa/pull/268>`__)
-
 
 
 1.1.0 (June 23, 2020)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,12 +26,18 @@ Release History
 **Added**
 
 - Differentiation between left, right, and two-sided special elements (identity,
-  zero, absorbing element) of an algebra.
+  zero, absorbing element, inverse) of an algebra.
+  (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
+- Added ``linv`` and ``rinv`` methods to ``SemanticPointer`` for the left and
+  right inverse, respectively.
+  (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
+- Add support for the ``normalized`` and ``unitary`` methods on Semantic Pointer
+  symbols.
   (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
 
 **Changed**
 
-- Creating special elements (identity, zero, absorbing element) of the
+- Creating special elements (identity, zero, absorbing element, inverse) of the
   ``VtbAlgebra`` without ``sidedness`` argument has been deprecated because
   these are only right-sided special element. Add the
   ``sidedness=ElementSidedness.RIGHT`` argument to update your code.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,41 +9,44 @@ import sys
 try:
     import nengo_spa
     import nengo_sphinx_theme
+
     assert nengo_sphinx_theme
 except ImportError:
-    print("To build the documentation, nengo_spa and nengo_sphinx_theme "
-          "must be installed in the current environment. Please install these "
-          "and their requirements first. A virtualenv is recommended!")
+    print(
+        "To build the documentation, nengo_spa and nengo_sphinx_theme "
+        "must be installed in the current environment. Please install these "
+        "and their requirements first. A virtualenv is recommended!"
+    )
     sys.exit(1)
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    'nbsphinx',
-    'nengo_sphinx_theme.ext.redirects',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "nbsphinx",
+    "nengo_sphinx_theme.ext.redirects",
 ]
 
-default_role = 'py:obj'
+default_role = "py:obj"
 numfig = True
 
 # -- sphinx.ext.autodoc
-autoclass_content = 'both'  # class and __init__ docstrings are concatenated
+autoclass_content = "both"  # class and __init__ docstrings are concatenated
 autodoc_default_options = {  # new in version 1.8
-    'members': None,
+    "members": None,
 }
-autodoc_member_order = 'bysource'  # default is alphabetical
+autodoc_member_order = "bysource"  # default is alphabetical
 
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {
-    'nengo': ('https://www.nengo.ai/nengo/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    "nengo": ("https://www.nengo.ai/nengo/", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
 }
 
 # -- sphinx.ext.todo
@@ -51,7 +54,7 @@ todo_include_todos = True
 
 # -- linkcheck
 linkcheck_ignore = [
-    r'^https?://www\.amazon\..*$',
+    r"^https?://www\.amazon\..*$",
 ]
 
 # -- doctest
@@ -60,34 +63,35 @@ doctest_global_setup = "import nengo_spa"
 # -- nbsphinx
 nbsphinx_allow_errors = False
 nbsphinx_timeout = 600
-nbsphinx_execute = 'always'
+nbsphinx_execute = "always"
 
 # -- sphinx
-exclude_patterns = ['_build', 'examples/.ipynb_checkpoints']
-source_suffix = '.rst'
-source_encoding = 'utf-8'
-master_doc = 'index'
+exclude_patterns = ["_build", "examples/.ipynb_checkpoints"]
+source_suffix = ".rst"
+source_encoding = "utf-8"
+master_doc = "index"
 
 # Need to include https Mathjax path for sphinx < v1.3
-mathjax_path = ("https://cdn.mathjax.org/mathjax/latest/MathJax.js"
-                "?config=TeX-AMS-MML_HTMLorMML")
+mathjax_path = (
+    "https://cdn.mathjax.org/mathjax/latest/MathJax.js" "?config=TeX-AMS-MML_HTMLorMML"
+)
 
-project = u'NengoSPA'
-authors = u'Applied Brain Research'
+project = u"NengoSPA"
+authors = u"Applied Brain Research"
 copyright = nengo_spa.__copyright__
-version = '.'.join(nengo_spa.__version__.split('.')[:2])  # Short X.Y version
+version = ".".join(nengo_spa.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_spa.__version__  # Full version, with tags
-pygments_style = 'friendly'
+pygments_style = "friendly"
 
 # -- Options for HTML output --------------------------------------------------
 
-html_theme = 'nengo_sphinx_theme'
+html_theme = "nengo_sphinx_theme"
 html_title = "NengoSPA {0} docs".format(release)
-html_static_path = ['_static']
-html_favicon = os.path.join('_static', 'favicon.ico')
+html_static_path = ["_static"]
+html_favicon = os.path.join("_static", "favicon.ico")
 html_use_smartypants = True
-htmlhelp_basename = 'Nengodoc'
-html_last_updated_fmt = ''  # Suppress 'Last updated on:' timestamp
+htmlhelp_basename = "Nengodoc"
+html_last_updated_fmt = ""  # Suppress 'Last updated on:' timestamp
 html_show_sphinx = False
 html_theme_options = {
     "nengo_logo": "nengo-spa-full-light.svg",
@@ -95,42 +99,42 @@ html_theme_options = {
     "analytics_id": "UA-41658423-2",
 }
 html_redirects = [
-    (old, old.replace('_', '-')) for old in
-    (
-        'dev_syntax.html',
-        'examples/associative_memory.html',
-        'examples/custom_module.html',
-        'examples/intro_coming_from_legacy_spa.html',
-        'examples/question_control.html',
-        'examples/question_memory.html',
-        'examples/spa_parser.html',
-        'examples/spa_sequence_routed.html',
-        'examples/spa_sequence.html',
-        'examples/vocabulary_casting.html',
-        'getting_started.html',
-        'user_guide.html',
-        'user_guide/algebras.html',
-        'user_guide/spa_intro.html',
+    (old, old.replace("_", "-"))
+    for old in (
+        "dev_syntax.html",
+        "examples/associative_memory.html",
+        "examples/custom_module.html",
+        "examples/intro_coming_from_legacy_spa.html",
+        "examples/question_control.html",
+        "examples/question_memory.html",
+        "examples/spa_parser.html",
+        "examples/spa_sequence_routed.html",
+        "examples/spa_sequence.html",
+        "examples/vocabulary_casting.html",
+        "getting_started.html",
+        "user_guide.html",
+        "user_guide/algebras.html",
+        "user_guide/spa_intro.html",
     )
 ]
 
 # -- Options for LaTeX output -------------------------------------------------
 
 latex_elements = {
-    'papersize': 'letterpaper',
-    'pointsize': '11pt',
+    "papersize": "letterpaper",
+    "pointsize": "11pt",
 }
 
 latex_documents = [
     # (source start file, target, title, author, documentclass [howto/manual])
-    ('index', 'nengo.tex', html_title, authors, 'manual'),
+    ("index", "nengo.tex", html_title, authors, "manual"),
 ]
 
 # -- Options for manual page output -------------------------------------------
 
 man_pages = [
     # (source start file, name, description, authors, manual section).
-    ('index', 'nengo', html_title, [authors], 1)
+    ("index", "nengo", html_title, [authors], 1)
 ]
 
 # -- Options for Texinfo output -----------------------------------------------
@@ -138,6 +142,13 @@ man_pages = [
 texinfo_documents = [
     # (source start file, target, title, author, dir menu entry,
     #  description, category)
-    ('index', 'nengo', html_title, authors, 'Nengo',
-     'Large-scale neural simulation in Python', 'Miscellaneous'),
+    (
+        "index",
+        "nengo",
+        html_title,
+        authors,
+        "Nengo",
+        "Large-scale neural simulation in Python",
+        "Miscellaneous",
+    ),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ todo_include_todos = True
 # -- linkcheck
 linkcheck_ignore = [
     r"^https?://www\.amazon\..*$",
+    r"^https://uwspace\.uwaterloo\.ca.*$",
 ]
 
 # -- doctest

--- a/docs/modules/nengo_spa.algebras.rst
+++ b/docs/modules/nengo_spa.algebras.rst
@@ -3,10 +3,12 @@ nengo\_spa\.algebras
 
 .. automodule:: nengo_spa.algebras
    :members:
+   :undoc-members:
    :imported-members:
 
    .. autosummary::
 
       AbstractAlgebra
+      ElementSidedness
       HrrAlgebra
       VtbAlgebra

--- a/docs/modules/nengo_spa.networks.rst
+++ b/docs/modules/nengo_spa.networks.rst
@@ -9,6 +9,8 @@ nengo\_spa\.networks
 
       CircularConvolution
       IdentityEnsembleArray
+      MatrixMult
+      VTB
 
    .. rubric:: Selection networks
 

--- a/docs/modules/nengo_spa.semantic_pointer.rst
+++ b/docs/modules/nengo_spa.semantic_pointer.rst
@@ -15,4 +15,5 @@ nengo\_spa\.semantic_pointer
       Zero
 
    .. autoclass:: SemanticPointer
+      :special-members: __invert__
       :exclude-members: connect_to, construct, evaluate

--- a/docs/modules/nengo_spa.vocabulary.rst
+++ b/docs/modules/nengo_spa.vocabulary.rst
@@ -2,6 +2,7 @@ nengo\_spa\.vocabulary
 ======================
 
 .. automodule:: nengo_spa.vocabulary
+   :exclude-members: iskeyword
 
    .. rubric:: Classes
 

--- a/docs/user-guide/algebras.rst
+++ b/docs/user-guide/algebras.rst
@@ -2,7 +2,7 @@ Algebras
 --------
 
 NengoSPA uses elementwise addition for superposition and circular convolution
-for binding (`.CircularConvolutionAlgebra`) by default. However, other choices are
+for binding (`.HrrAlgebra`) by default. However, other choices are
 viable. In NengoSPA we call such a specific choice of such operators an
 *algebra*. It is easy to change the algebra that is used by NengoSPA as it is
 tied to the vocabulary. To use a different algebra, it suffices to manually
@@ -26,7 +26,14 @@ Note that circular convolution is commutative, i.e. :math:`a \circledast
 b = b \circledast a`, but this is not true for all algebras. In
 particular, the VTB is not commutative. That
 means you have to pay attention from which side vectors are bound and unbound.
-Moreover, when given :math:`\mathcal{B}(\mathcal{B}(a, b), c)`, it is not
+For such non-commutative algebras, special elements like the identity,
+absorbing element, zero element, and inverse might only fulfil their properties
+on a specific side of the binding operation. In these cases, the method to
+obtain the element usually has a ``sidedness`` argument to specify for which
+side of the binding operation the element is requested. For the inverse,
+however, you have the choice between ``~`` for the two-sided inverse, `.linv()`
+and `.rinv()` for the left and right inverse, respectively.
+Moreover, when given :math:`\mathcal{B}(\mathcal{B}(a, b), c)` in VTB, it is not
 possible to directly unbind :math:`a`, but :math:`c` has to be unbound first
 because VTB is not associative.
 

--- a/nengo_spa/algebras/__init__.py
+++ b/nengo_spa/algebras/__init__.py
@@ -1,5 +1,5 @@
 """Algebras define the specific superposition and (un)binding operations."""
 
-from .base import AbstractAlgebra
+from .base import AbstractAlgebra, ElementSidedness
 from .hrr_algebra import HrrAlgebra
 from .vtb_algebra import VtbAlgebra

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -1,5 +1,14 @@
 from abc import ABCMeta
+from enum import Enum
 import warnings
+
+
+class ElementSidedness(Enum):
+    """The side in a binary operation for which a special element's properties hold."""
+
+    LEFT = "left"
+    RIGHT = "right"
+    TWO_SIDED = "two-sided"
 
 
 class _DuckTypedABCMeta(ABCMeta):
@@ -201,7 +210,7 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
-    def absorbing_element(self, d):
+    def absorbing_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         """Return the standard absorbing element of dimensionality *d*.
 
         An absorbing element will produce a scaled version of itself when bound
@@ -215,6 +224,8 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            Side in the binding operation on which the element absorbs.
 
         Returns
         -------
@@ -223,15 +234,20 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
-    def identity_element(self, d):
+    def identity_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         """Return the identity element of dimensionality *d*.
 
         The identity does not change the vector it is bound to.
+
+        Some algebras might not have an identity element. In that case a
+        *NotImplementedError* may be raised.
 
         Parameters
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            Side in the binding operation on which the element acts as identity.
 
         Returns
         -------
@@ -240,16 +256,21 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
-    def zero_element(self, d):
+    def zero_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         """Return the zero element of dimensionality *d*.
 
         The zero element produces itself when bound to a different vector.
         Usually this will be the zero vector.
 
+        Some algebras might not have a zero element. In that case a
+        *NotImplementedError* may be raised.
+
         Parameters
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            Side in the binding operation on which the element acts as zero.
 
         Returns
         -------

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -113,15 +113,21 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
-    def invert(self, v):
+    def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
         """Invert vector *v*.
 
         A vector bound to its inverse will result in the identity vector.
+
+        Some algebras might not have an inverse only on specific sides. In that
+        case a *NotImplementedError* may be raised for non-existing inverses.
 
         Parameters
         ----------
         v : (d,) ndarray
             Vector to invert.
+        sidedness : ElementSidedness, optional
+            Side in the binding operation on which the returned value acts as
+            inverse.
 
         Returns
         -------
@@ -151,13 +157,19 @@ class AbstractAlgebra(metaclass=_DuckTypedABCMeta):
         """
         raise NotImplementedError()
 
-    def get_inversion_matrix(self, d):
+    def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
         """Returns the transformation matrix for inverting a vector.
+
+        Some algebras might not have an inverse only on specific sides. In that
+        case a *NotImplementedError* may be raised for non-existing inverses.
 
         Parameters
         ----------
         d : int
             Vector dimensionality (determines the matrix size).
+        sidedness : ElementSidedness, optional
+            Side in the binding operation on which a transformed vectors acts as
+            inverse.
 
         Returns
         -------

--- a/nengo_spa/algebras/hrr_algebra.py
+++ b/nengo_spa/algebras/hrr_algebra.py
@@ -82,7 +82,7 @@ class HrrAlgebra(AbstractAlgebra):
             raise ValueError("Inputs must have same length.")
         return np.fft.irfft(np.fft.rfft(a) * np.fft.rfft(b), n=n)
 
-    def invert(self, v):
+    def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
         return v[-np.arange(len(v))]
 
     def get_binding_matrix(self, v, swap_inputs=False):
@@ -92,7 +92,7 @@ class HrrAlgebra(AbstractAlgebra):
             T.append([v[(i - j) % D] for j in range(D)])
         return np.array(T)
 
-    def get_inversion_matrix(self, d):
+    def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
         return np.eye(d)[-np.arange(d)]
 
     def implement_superposition(self, n_neurons_per_d, d, n):

--- a/nengo_spa/algebras/hrr_algebra.py
+++ b/nengo_spa/algebras/hrr_algebra.py
@@ -1,7 +1,7 @@
 import nengo
 import numpy as np
 
-from nengo_spa.algebras.base import AbstractAlgebra
+from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
 from nengo_spa.networks.circularconvolution import CircularConvolution
 
 
@@ -103,7 +103,7 @@ class HrrAlgebra(AbstractAlgebra):
         net = CircularConvolution(n_neurons_per_d, d, unbind_left, unbind_right)
         return net, (net.input_a, net.input_b), net.output
 
-    def absorbing_element(self, d):
+    def absorbing_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         r"""Return the standard absorbing element of dimensionality *d*.
 
         An absorbing element will produce a scaled version of itself when bound
@@ -117,6 +117,9 @@ class HrrAlgebra(AbstractAlgebra):
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the HRR algebra is commutative
+            and the standard absorbing element is two-sided.
 
         Returns
         -------
@@ -125,7 +128,7 @@ class HrrAlgebra(AbstractAlgebra):
         """
         return np.ones(d) / np.sqrt(d)
 
-    def identity_element(self, d):
+    def identity_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         r"""Return the identity element of dimensionality *d*.
 
         The identity does not change the vector it is bound to.
@@ -137,6 +140,9 @@ class HrrAlgebra(AbstractAlgebra):
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the HRR algebra is commutative
+            and the identity is two-sided.
 
         Returns
         -------
@@ -147,7 +153,7 @@ class HrrAlgebra(AbstractAlgebra):
         data[0] = 1.0
         return data
 
-    def zero_element(self, d):
+    def zero_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
         """Return the zero element of dimensionality *d*.
 
         The zero element produces itself when bound to a different vector.
@@ -157,6 +163,9 @@ class HrrAlgebra(AbstractAlgebra):
         ----------
         d : int
             Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the HRR algebra is commutative
+            and the zero element is two-sided.
 
         Returns
         -------

--- a/nengo_spa/algebras/hrr_algebra.py
+++ b/nengo_spa/algebras/hrr_algebra.py
@@ -83,6 +83,28 @@ class HrrAlgebra(AbstractAlgebra):
         return np.fft.irfft(np.fft.rfft(a) * np.fft.rfft(b), n=n)
 
     def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
+        """Invert vector *v*.
+
+        This turns circular convolution into circular correlation, meaning that
+        ``A*B*~B`` is approximately ``A``.
+
+        Examples
+        --------
+        For the vector ``[1, 2, 3, 4, 5]``, the inverse is ``[1, 5, 4, 3, 2]``.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to invert.
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the HRR algebra is commutative
+            and the inverse is two-sided.
+
+        Returns
+        -------
+        (d,) ndarray
+            Inverted vector.
+        """
         return v[-np.arange(len(v))]
 
     def get_binding_matrix(self, v, swap_inputs=False):
@@ -93,6 +115,21 @@ class HrrAlgebra(AbstractAlgebra):
         return np.array(T)
 
     def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Returns the transformation matrix for inverting a vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality (determines the matrix size).
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the HRR algebra is commutative
+            and the inverse is two-sided.
+
+        Returns
+        -------
+        (d, d) ndarray
+            Transformation matrix to invert a vector.
+        """
         return np.eye(d)[-np.arange(d)]
 
     def implement_superposition(self, n_neurons_per_d, d, n):

--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -42,8 +42,16 @@ class VtbAlgebra(AbstractAlgebra):
     Note that VTB requires the vector dimensionality to be square.
 
     The VTB binding operation is neither associative nor commutative.
+    Furthermore, there are right inverses and identities only.
 
-    Publications with further information are forthcoming.
+    Additional information about VTB can be found in
+
+    * `Gosmann, Jan, and Chris Eliasmith (2019). Vector-derived transformation binding:
+      an improved binding operation for deep symbol-like processing in
+      neural networks. Neural computation 31.5, 849-869.
+      <https://www.mitpressjournals.org/action/showCitFormats?doi=10.1162/neco_a_01179>`_
+    * `Jan Gosmann (2018). An Integrated Model of Context, Short-Term, and
+      Long-Term Memory. UWSpace. <https://uwspace.uwaterloo.ca/handle/10012/13498>`_
     """
 
     _instance = None
@@ -102,6 +110,30 @@ class VtbAlgebra(AbstractAlgebra):
         return np.dot(m, a)
 
     def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
+        """Invert vector *v*.
+
+        A vector bound to its inverse will result in the identity vector.
+
+        VTB has a right inverse only.
+
+        .. deprecated:: 1.2.0
+           Calling this method with the default
+           ``sidedness=ElementSidedness.TWO_SIDED`` returns the right inverse
+           for backwards compatibility, but has been deprecated and will be
+           removed in the next major release.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to invert.
+        sidedness : ElementSidedness
+            Must be set to `ElementSidedness.RIGHT`.
+
+        Returns
+        -------
+        (d,) ndarray
+            Right inverse of vector.
+        """
         if sidedness is ElementSidedness.LEFT:
             raise NotImplementedError("VtbAlgebra does not have a left inverse.")
         if sidedness is ElementSidedness.TWO_SIDED:
@@ -141,6 +173,29 @@ class VtbAlgebra(AbstractAlgebra):
         return self.get_inversion_matrix(d, sidedness=ElementSidedness.RIGHT)
 
     def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Returns the transformation matrix for inverting a vector.
+
+        VTB has a right inverse only.
+
+        .. deprecated:: 1.2.0
+           Calling this method with the default
+           ``sidedness=ElementSidedness.TWO_SIDED`` returns the right
+           transformation matrix for the right inverse for backwards
+           compatibility, but has been deprecated and will be removed in the
+           next major release.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+        sidedness : ElementSidedness
+            Must be set to `ElementSidedness.RIGHT`.
+
+        Returns
+        -------
+        (d, d) ndarray
+            Transformation matrix to invert a vector.
+        """
         if sidedness is ElementSidedness.LEFT:
             raise NotImplementedError("VtbAlgebra does not have a left inverse.")
         if sidedness is ElementSidedness.TWO_SIDED:
@@ -165,10 +220,35 @@ class VtbAlgebra(AbstractAlgebra):
         return net, (net.input_left, net.input_right), net.output
 
     def absorbing_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
-        """VTB has no absorbing element except the zero vector."""
+        """VTB has no absorbing element except the zero vector.
+
+        Always raises a `NotImplementedError`.
+        """
         raise NotImplementedError("VtbAlgebra does not have any absorbing elements.")
 
     def identity_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Return the identity element of dimensionality *d*.
+
+        VTB has a right identity only.
+
+        .. deprecated:: 1.2.0
+           Calling this method with the default
+           ``sidedness=ElementSidedness.TWO_SIDED`` returns the right identity
+           for backwards compatibility, but has been deprecated and will be
+           removed in the next major release.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+        sidedness : ElementSidedness
+            Must be set to `ElementSidedness.RIGHT`.
+
+        Returns
+        -------
+        (d,) ndarray
+            Right identity element.
+        """
         if sidedness is ElementSidedness.LEFT:
             raise NotImplementedError("VtbAlgebra does not have a left identity.")
         if sidedness is ElementSidedness.TWO_SIDED:

--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -101,7 +101,19 @@ class VtbAlgebra(AbstractAlgebra):
         m = self.get_binding_matrix(b)
         return np.dot(m, a)
 
-    def invert(self, v):
+    def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
+        if sidedness is ElementSidedness.LEFT:
+            raise NotImplementedError("VtbAlgebra does not have a left inverse.")
+        if sidedness is ElementSidedness.TWO_SIDED:
+            warnings.warn(
+                DeprecationWarning(
+                    "VtbAlgebra does not have a two-sided inverse, returning "
+                    "the right inverse instead. Please change your code to "
+                    "request the right inverse explicitly with "
+                    "`sidedness=ElementSidedness.RIGHT`."
+                )
+            )
+
         sub_d = self._get_sub_d(len(v))
         return v.reshape((sub_d, sub_d)).T.flatten()
 
@@ -126,9 +138,21 @@ class VtbAlgebra(AbstractAlgebra):
             Matrix to multiply with a vector to switch left and right operand
             in bound state.
         """
-        return self.get_inversion_matrix(d)
+        return self.get_inversion_matrix(d, sidedness=ElementSidedness.RIGHT)
 
-    def get_inversion_matrix(self, d):
+    def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        if sidedness is ElementSidedness.LEFT:
+            raise NotImplementedError("VtbAlgebra does not have a left inverse.")
+        if sidedness is ElementSidedness.TWO_SIDED:
+            warnings.warn(
+                DeprecationWarning(
+                    "VtbAlgebra does not have a two-sided inverse, returning "
+                    "the right inverse instead. Please change your code to "
+                    "request the right inverse explicitly with "
+                    "`sidedness=ElementSidedness.RIGHT`."
+                )
+            )
+
         sub_d = self._get_sub_d(d)
         return np.eye(d).reshape(d, sub_d, sub_d).T.reshape(d, d)
 

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -3,6 +3,7 @@
 import nengo
 import numpy as np
 
+from nengo_spa.algebras.base import ElementSidedness
 from nengo_spa.ast.base import infer_types, Node, TypeCheckedBinaryOp
 from nengo_spa.ast.symbolic import Fixed, FixedScalar, Symbol
 from nengo_spa.exceptions import SpaTypeError
@@ -33,12 +34,23 @@ class DynamicNode(Node):
     """Base class for AST node with an output that changes over time."""
 
     def __invert__(self):
+        return self.__invert_impl(sidedness=ElementSidedness.TWO_SIDED)
+
+    def linv(self):
+        return self.__invert_impl(sidedness=ElementSidedness.LEFT)
+
+    def rinv(self):
+        return self.__invert_impl(sidedness=ElementSidedness.RIGHT)
+
+    def __invert_impl(self, sidedness):
         if not hasattr(self.type, "vocab"):
             raise SpaTypeError(
                 "Cannot invert semantic pointer with unknown vocabulary."
             )
         dimensions = self.type.vocab.dimensions
-        transform = self.type.vocab.algebra.get_inversion_matrix(dimensions)
+        transform = self.type.vocab.algebra.get_inversion_matrix(
+            dimensions, sidedness=sidedness
+        )
         return Transformed(self, transform, self.type)
 
     def __neg__(self):

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -88,6 +88,12 @@ class PointerSymbol(Symbol):
     def __invert__(self):
         return PointerSymbol(~self._expr_tree, self.type)
 
+    def linv(self):
+        return PointerSymbol(self.expr + ".linv()", self.type)
+
+    def rinv(self):
+        return PointerSymbol(self.expr + ".rinv()", self.type)
+
     def __neg__(self):
         return PointerSymbol(-self._expr_tree, self.type)
 

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -85,6 +85,12 @@ class PointerSymbol(Symbol):
     def expr(self):
         return str(self._expr_tree)
 
+    def normalized(self):
+        return PointerSymbol(self.expr + ".normalized()", self.type)
+
+    def unitary(self):
+        return PointerSymbol(self.expr + ".unitary()", self.type)
+
     def __invert__(self):
         return PointerSymbol(~self._expr_tree, self.type)
 

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -52,6 +52,17 @@ def test_unary_operation_on_pointer_symbol(op, rng):
     assert_equal(node.output, vocab.parse(op + "A").v)
 
 
+@pytest.mark.parametrize("sidedness", ["l", "r"])
+def test_sided_inverse_on_pointer_symbol(sidedness, rng):
+    vocab = spa.Vocabulary(16, pointer_gen=rng)
+    vocab.populate("A")
+
+    with spa.Network():
+        x = eval("PointerSymbol('A', TVocabulary(vocab))." + sidedness + "inv()")
+        node = x.construct()
+    assert_equal(node.output, vocab.parse("A." + sidedness + "inv()").v)
+
+
 @pytest.mark.parametrize("op", ["+", "-", "*"])
 def test_binary_operation_on_pointer_symbols(op, rng):
     vocab = spa.Vocabulary(16, pointer_gen=rng)

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -52,15 +52,15 @@ def test_unary_operation_on_pointer_symbol(op, rng):
     assert_equal(node.output, vocab.parse(op + "A").v)
 
 
-@pytest.mark.parametrize("sidedness", ["l", "r"])
-def test_sided_inverse_on_pointer_symbol(sidedness, rng):
+@pytest.mark.parametrize("method", ["linv", "rinv", "normalized", "unitary"])
+def test_unary_method_on_pointer_symbol(method, rng):
     vocab = spa.Vocabulary(16, pointer_gen=rng)
     vocab.populate("A")
 
     with spa.Network():
-        x = eval("PointerSymbol('A', TVocabulary(vocab))." + sidedness + "inv()")
+        x = eval("PointerSymbol('A', TVocabulary(vocab))." + method + "()")
         node = x.construct()
-    assert_equal(node.output, vocab.parse("A." + sidedness + "inv()").v)
+    assert_equal(node.output, vocab.parse("A." + method + "()").v)
 
 
 @pytest.mark.parametrize("op", ["+", "-", "*"])

--- a/nengo_spa/connectors.py
+++ b/nengo_spa/connectors.py
@@ -156,6 +156,8 @@ class SpaOperatorMixin:
         return op_impl
 
     __invert__ = __define_unary_op.__func__("__invert__")
+    linv = __define_unary_op.__func__("linv")
+    rinv = __define_unary_op.__func__("rinv")
     __neg__ = __define_unary_op.__func__("__neg__")
 
     __add__ = __define_binary_op.__func__("__add__")

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -72,5 +72,5 @@ def test_unbind(Simulator, algebra, side, seed, rng):
         sim.run(0.2)
 
     assert_sp_close(
-        sim.trange(), sim.data[p], vocab.parse("A * B * ~B"), skip=0.15, atol=0.3
+        sim.trange(), sim.data[p], vocab.parse("A * B * B.rinv()"), skip=0.15, atol=0.3
     )

--- a/nengo_spa/networks/tests/test_vtb.py
+++ b/nengo_spa/networks/tests/test_vtb.py
@@ -49,5 +49,5 @@ def test_unbind(Simulator, side, seed, rng):
         sim.run(0.2)
 
     assert_sp_close(
-        sim.trange(), sim.data[p], vocab.parse("A * B * ~B"), skip=0.15, atol=0.3
+        sim.trange(), sim.data[p], vocab.parse("A * B * B.rinv()"), skip=0.15, atol=0.3
     )

--- a/nengo_spa/networks/vtb.py
+++ b/nengo_spa/networks/vtb.py
@@ -67,7 +67,14 @@ class VTB(nengo.Network):
 
     The VTB binding operation is neither associative nor commutative.
 
-    Publications with further information are forthcoming.
+    Additional information about VTB can be found in
+
+    * `Gosmann, Jan, and Chris Eliasmith (2019). Vector-derived transformation binding:
+      an improved binding operation for deep symbol-like processing in
+      neural networks. Neural computation 31.5, 849-869.
+      <https://www.mitpressjournals.org/action/showCitFormats?doi=10.1162/neco_a_01179>`_
+    * `Jan Gosmann (2018). An Integrated Model of Context, Short-Term, and
+      Long-Term Memory. UWSpace. <https://uwspace.uwaterloo.ca/handle/10012/13498>`_
 
     Parameters
     ----------

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -255,18 +255,43 @@ class SemanticPointer(Fixed):
             return NotImplemented
 
     def __invert__(self):
-        """Return a reorganized vector that acts as an inverse for convolution.
+        """Return a reorganized vector that acts as a two-sided inverse for
+        binding.
+
+        When using the (default) ``HrrAlgebra``:
 
         This reorganization turns circular convolution into circular
         correlation, meaning that ``A*B*~B`` is approximately ``A``.
 
         For the vector ``[1, 2, 3, 4, 5]``, the inverse is ``[1, 5, 4, 3, 2]``.
+
+        See also
+        --------
+        linv, rinv
         """
         return SemanticPointer(
-            data=self.algebra.invert(self.v),
+            data=self.algebra.invert(self.v, sidedness=ElementSidedness.TWO_SIDED),
             vocab=self.vocab,
             algebra=self.algebra,
             name=self._get_unary_name("~"),
+        )
+
+    def linv(self):
+        """Return a reorganized vector that acts as the left inverse for binding."""
+        return SemanticPointer(
+            data=self.algebra.invert(self.v, sidedness=ElementSidedness.LEFT),
+            vocab=self.vocab,
+            algebra=self.algebra,
+            name=self._get_method_name("rinv"),
+        )
+
+    def rinv(self):
+        """Return a reorganized vector that acts as the right inverse for binding."""
+        return SemanticPointer(
+            data=self.algebra.invert(self.v, sidedness=ElementSidedness.RIGHT),
+            vocab=self.vocab,
+            algebra=self.algebra,
+            name=self._get_method_name("rinv"),
         )
 
     def bind(self, other):

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -13,7 +13,9 @@ class SemanticPointer(Fixed):
     """A Semantic Pointer, based on Holographic Reduced Representations.
 
     Operators are overloaded so that ``+`` and ``-`` are addition,
-    ``*`` is circular convolution, and ``~`` is the inversion operator.
+    ``*`` is circular convolution, and ``~`` is the two-sided inversion operator.
+    The left and right inverese can be obtained with the `linv` and `rinv`
+    methods.
 
     Parameters
     ----------
@@ -24,7 +26,7 @@ class SemanticPointer(Fixed):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     name : str, optional
         A name for the Semantic Pointer.
@@ -255,19 +257,10 @@ class SemanticPointer(Fixed):
             return NotImplemented
 
     def __invert__(self):
-        """Return a reorganized vector that acts as a two-sided inverse for
-        binding.
+        """Return a reorganized `SemanticPointer` that acts as a two-sided
+        inverse for binding.
 
-        When using the (default) ``HrrAlgebra``:
-
-        This reorganization turns circular convolution into circular
-        correlation, meaning that ``A*B*~B`` is approximately ``A``.
-
-        For the vector ``[1, 2, 3, 4, 5]``, the inverse is ``[1, 5, 4, 3, 2]``.
-
-        See also
-        --------
-        linv, rinv
+        .. seealso:: linv, rinv
         """
         return SemanticPointer(
             data=self.algebra.invert(self.v, sidedness=ElementSidedness.TWO_SIDED),
@@ -277,7 +270,11 @@ class SemanticPointer(Fixed):
         )
 
     def linv(self):
-        """Return a reorganized vector that acts as the left inverse for binding."""
+        """Return a reorganized `SemanticPointer` that acts as a left inverse
+        for binding.
+
+        .. seealso:: `__invert__`, `rinv`
+        """
         return SemanticPointer(
             data=self.algebra.invert(self.v, sidedness=ElementSidedness.LEFT),
             vocab=self.vocab,
@@ -286,7 +283,11 @@ class SemanticPointer(Fixed):
         )
 
     def rinv(self):
-        """Return a reorganized vector that acts as the right inverse for binding."""
+        """Return a reorganized `SemanticPointer` that acts as a right inverse
+        for binding.
+
+        .. seealso:: `__invert__`, `linv`
+        """
         return SemanticPointer(
             data=self.algebra.invert(self.v, sidedness=ElementSidedness.RIGHT),
             vocab=self.vocab,
@@ -433,7 +434,7 @@ class Identity(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive
         with the *vocab* argument.
     sidedness : ElementSidedness, optional
         Side in the binding operation on which the element acts as identity.
@@ -471,8 +472,8 @@ class AbsorbingElement(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
-        with the *vocab* argument.
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive with the *vocab*
+        argument.
     sidedness : ElementSidedness, optional
         Side in the binding operation on which the element acts as absorbing element.
     """
@@ -505,8 +506,8 @@ class Zero(SemanticPointer):
         Mutually exclusive with the *algebra* argument.
     algebra : AbstractAlgebra, optional
         Algebra used to perform vector symbolic operations on the Semantic
-        Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
-        with the *vocab* argument.
+        Pointer. Defaults to `.HrrAlgebra`. Mutually exclusive with the *vocab*
+        argument.
     sidedness : ElementSidedness, optional
         Side in the binding operation on which the element acts as zero element.
     """

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -2,7 +2,7 @@ import nengo
 from nengo.exceptions import ValidationError
 import numpy as np
 
-from nengo_spa.algebras.base import AbstractAlgebra
+from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.ast.base import Fixed, infer_types, TypeCheckedBinaryOp
 from nengo_spa.typechecks import is_array, is_array_like, is_number
@@ -410,10 +410,21 @@ class Identity(SemanticPointer):
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the *vocab* argument.
+    sidedness : ElementSidedness, optional
+        Side in the binding operation on which the element acts as identity.
     """
 
-    def __init__(self, n_dimensions, vocab=None, algebra=None):
-        data = self._get_algebra(vocab, algebra).identity_element(n_dimensions)
+    def __init__(
+        self,
+        n_dimensions,
+        vocab=None,
+        algebra=None,
+        *,
+        sidedness=ElementSidedness.TWO_SIDED
+    ):
+        data = self._get_algebra(vocab, algebra).identity_element(
+            n_dimensions, sidedness=sidedness
+        )
         super(Identity, self).__init__(
             data, vocab=vocab, algebra=algebra, name="Identity"
         )
@@ -437,10 +448,21 @@ class AbsorbingElement(SemanticPointer):
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the *vocab* argument.
+    sidedness : ElementSidedness, optional
+        Side in the binding operation on which the element acts as absorbing element.
     """
 
-    def __init__(self, n_dimensions, vocab=None, algebra=None):
-        data = self._get_algebra(vocab, algebra).absorbing_element(n_dimensions)
+    def __init__(
+        self,
+        n_dimensions,
+        vocab=None,
+        algebra=None,
+        *,
+        sidedness=ElementSidedness.TWO_SIDED
+    ):
+        data = self._get_algebra(vocab, algebra).absorbing_element(
+            n_dimensions, sidedness=sidedness
+        )
         super(AbsorbingElement, self).__init__(
             data, vocab=vocab, algebra=algebra, name="AbsorbingElement"
         )
@@ -460,8 +482,18 @@ class Zero(SemanticPointer):
         Algebra used to perform vector symbolic operations on the Semantic
         Pointer. Defaults to `.CircularConvolutionAlgebra`. Mutually exclusive
         with the *vocab* argument.
+    sidedness : ElementSidedness, optional
+        Side in the binding operation on which the element acts as zero element.
     """
 
-    def __init__(self, n_dimensions, vocab=None, algebra=None):
-        data = self._get_algebra(vocab, algebra).zero_element(n_dimensions)
+    def __init__(
+        self,
+        n_dimensions,
+        vocab=None,
+        algebra=None,
+        sidedness=ElementSidedness.TWO_SIDED,
+    ):
+        data = self._get_algebra(vocab, algebra).zero_element(
+            n_dimensions, sidedness=sidedness
+        )
         super(Zero, self).__init__(data, vocab=vocab, algebra=algebra, name="Zero")

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_equal
 import pytest
 
 import nengo_spa as spa
-from nengo_spa.algebras.base import AbstractAlgebra
+from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
@@ -100,7 +100,7 @@ def test_binding_and_inversion(algebra, d, rng):
 
     a = SemanticPointer(next(gen), algebra=algebra)
     b = SemanticPointer(next(gen), algebra=algebra)
-    identity = Identity(d, algebra=algebra)
+    identity = Identity(d, algebra=algebra, sidedness=ElementSidedness.RIGHT)
 
     c = a.copy()
     c *= b
@@ -307,22 +307,41 @@ def test_invalid_algebra():
     SemanticPointer(next(gen), algebra=HrrAlgebra())
 
 
-def test_identity(algebra):
-    assert np.allclose(Identity(64, algebra=algebra).v, algebra.identity_element(64))
-
-
-def test_absorbing_element(algebra, plt):
-    plt.plot([0, 1], [0, 1])
+@pytest.mark.filterwarnings("ignore:.*:DeprecationWarning")
+@pytest.mark.parametrize("sidedness", ElementSidedness)
+def test_identity(algebra, sidedness):
     try:
         assert np.allclose(
-            AbsorbingElement(64, algebra=algebra).v, algebra.absorbing_element(64)
+            Identity(64, algebra=algebra, sidedness=sidedness).v,
+            algebra.identity_element(64, sidedness=sidedness),
         )
     except NotImplementedError:
         pass
 
 
-def test_zero(algebra):
-    assert np.allclose(Zero(64, algebra=algebra).v, algebra.zero_element(64))
+@pytest.mark.filterwarnings("ignore:.*:DeprecationWarning")
+@pytest.mark.parametrize("sidedness", ElementSidedness)
+def test_absorbing_element(algebra, sidedness, plt):
+    plt.plot([0, 1], [0, 1])
+    try:
+        assert np.allclose(
+            AbsorbingElement(64, algebra=algebra, sidedness=sidedness).v,
+            algebra.absorbing_element(64, sidedness=sidedness),
+        )
+    except NotImplementedError:
+        pass
+
+
+@pytest.mark.filterwarnings("ignore:.*:DeprecationWarning")
+@pytest.mark.parametrize("sidedness", ElementSidedness)
+def test_zero(algebra, sidedness):
+    try:
+        assert np.allclose(
+            Zero(64, algebra=algebra, sidedness=sidedness).v,
+            algebra.zero_element(64, sidedness=sidedness),
+        )
+    except NotImplementedError:
+        pass
 
 
 def test_name():

--- a/nengo_spa/version.py
+++ b/nengo_spa/version.py
@@ -7,7 +7,7 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "nengo_spa"
-version_info = (1, 1, 2)  # (major, minor, patch)
+version_info = (1, 2, 0)  # (major, minor, patch)
 dev = True
 
 version = "{v}{dev}".format(

--- a/nengo_spa/version.py
+++ b/nengo_spa/version.py
@@ -1,6 +1,6 @@
 """NengoSPA version information.
 
-We use semantic versioning (see https://semver.org/).
+We use semantic versioning (see https://semver.org/),
 and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
 '.devN' will be added to the version unless the code base represents
 a release version. Release versions are git tagged with the version.

--- a/nengo_spa/vocabulary.py
+++ b/nengo_spa/vocabulary.py
@@ -59,7 +59,7 @@ class Vocabulary(Mapping):
         A name to display in the string representation of this vocabulary.
     algebra : AbstractAlgebra, optional
         Defines the vector symbolic operators used for Semantic Pointers in the
-        vocabulary. Defaults to `.CircularConvolutionAlgebra`.
+        vocabulary. Defaults to `.HrrAlgebra`.
 
     Attributes
     ----------


### PR DESCRIPTION
**Motivation and context:**
So far NengoSPA assumed that all special elements (i.e. identity, zero, absorbing element, and inverse) of an algebra are two-sided, i.e. can be applied to either side in the binding with the same effect. While this is true for HRR/circular convolution, it does not hold in general. In particular, VTB only has a right identity and inverse(*), and by transposing the VTB-matrix a variant is obtained where there are only a left identity and inverse.

This PR changes things, so that one can explicitly ask for the left, right or two-sided inverse. In most methods this is done via a new `sidedness` argument taking a corresponding enum value. For backwards compatibility this argument is `ElementSidedness.TWO_SIDED` by default. Furthermore, for VTB this value will return the right identity or right inverse, but produce a deprecation warning. With Semantic Pointers `~` is used as inversion operator and it is not possible to add an additional argument here. Thus, `~` will be explicitly for the two-sided inverse. It still works with VTB, but again will produce a deprecation warning. For VTB SPs `.rinv()` can be used and there is `.linv()` for symmetry.

(*) Interestingly, it is still possible to unbind from the left, but this is not done by obtaining an inverse of the the left operand, but by applying the swapping matrix to the right (bound) vector and then using the right inverse from the right side to unbind.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
The necessity for this changes became evident during discussing PR #243, in particular [this thread](https://github.com/nengo/nengo-spa/pull/243#discussion_r429616559). It has not been obvious that VTB identity vectors and inverses are only right-sided.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Additional and existing tests. Some changes where necessary to handle missing special elements of one side in the generic tests, as well as some handling of the deprecation warnings where behaviour deviates from what sidedness is requested for backwards compatibility.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
