### PR TITLE
Implement TVTB algebra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ Release History
 
 **Added**
 
+- Transposed Vector-derived Transformation Binding (TVTB) algebra which has
+  essentially the same properties as the existing VTB algebra, but has two-sided
+  identities and inverses (opposed to VTB where these are right-sided only).
+  The only difference in the math is that TVTB transposes the matrix used in the
+  binding operation.
+  (`#266 <https://github.com/nengo/nengo_spa/issues/266>`__)
 - Differentiation between left, right, and two-sided special elements (identity,
   zero, absorbing element, inverse) of an algebra.
   (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)

--- a/docs/modules/nengo_spa.algebras.rst
+++ b/docs/modules/nengo_spa.algebras.rst
@@ -12,3 +12,4 @@ nengo\_spa\.algebras
       ElementSidedness
       HrrAlgebra
       VtbAlgebra
+      TvtbAlgebra

--- a/docs/modules/nengo_spa.networks.rst
+++ b/docs/modules/nengo_spa.networks.rst
@@ -11,6 +11,7 @@ nengo\_spa\.networks
       IdentityEnsembleArray
       MatrixMult
       VTB
+      TVTB
 
    .. rubric:: Selection networks
 

--- a/nengo_spa/algebras/__init__.py
+++ b/nengo_spa/algebras/__init__.py
@@ -3,3 +3,4 @@
 from .base import AbstractAlgebra, ElementSidedness
 from .hrr_algebra import HrrAlgebra
 from .vtb_algebra import VtbAlgebra
+from .tvtb_algebra import TvtbAlgebra

--- a/nengo_spa/algebras/tests/test_algebras.py
+++ b/nengo_spa/algebras/tests/test_algebras.py
@@ -52,7 +52,7 @@ def test_binding_and_invert(algebra, d, sidedness, rng):
                 warnings.simplefilter("error", DeprecationWarning)
                 if binding_side is ElementSidedness.LEFT:
                     bound = algebra.bind(b, a)
-                    r = algebra.bind(bound, algebra.invert(b, sidedness=sidedness))
+                    r = algebra.bind(algebra.invert(b, sidedness=sidedness), bound)
                 elif binding_side is ElementSidedness.RIGHT:
                     bound = algebra.bind(a, b)
                     r = algebra.bind(bound, algebra.invert(b, sidedness=sidedness))
@@ -82,8 +82,10 @@ def test_get_binding_matrix(algebra, rng):
     b = next(gen)
 
     m = algebra.get_binding_matrix(b)
-
     assert np.allclose(algebra.bind(a, b), np.dot(m, a))
+
+    m = algebra.get_binding_matrix(b, swap_inputs=True)
+    assert np.allclose(algebra.bind(b, a), np.dot(m, a))
 
 
 @pytest.mark.filterwarnings("ignore:.*sidedness:DeprecationWarning")

--- a/nengo_spa/algebras/tvtb_algebra.py
+++ b/nengo_spa/algebras/tvtb_algebra.py
@@ -1,0 +1,206 @@
+import nengo
+import numpy as np
+
+from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
+from nengo_spa.networks.tvtb import TVTB
+
+
+class TvtbAlgebra(AbstractAlgebra):
+    r"""Transposed Vector-derived Transformation Binding (TVTB) algebra.
+
+    TVTB uses elementwise addition for superposition. The binding operation
+    :math:`\mathcal{B}(x, y)` is defined as
+
+    .. math::
+
+       \mathcal{B}(x, y) := V_y^T x = \left[\begin{array}{ccc}
+           V_y'^T &      0 &      0 \\
+              0   & V_y'^T &      0 \\
+              0   &      0 & V_y'^T
+           \end{array}\right] x
+
+    with
+
+    .. math::
+
+       V_y' = d^{\frac{1}{4}} \left[\begin{array}{cccc}
+           y_1            & y_2            & \dots  & y_{d'}  \\
+           y_{d' + 1}     & y_{d' + 2}     & \dots  & y_{2d'} \\
+           \vdots         & \vdots         & \ddots & \vdots  \\
+           y_{d - d' + 1} & y_{d - d' + 2} & \dots  & y_d
+       \end{array}\right]
+
+    and
+
+    .. math:: d'^2 = d.
+
+    The approximate inverse :math:`y^+` for :math:`y` is permuting the elements
+    such that :math:`V_{y^+} = V_y^T`.
+
+    Note that TVTB requires the vector dimensionality to be square.
+
+    The TVTB binding operation is neither associative nor commutative.
+    In contrast to VTB, however, TVTB has two-sided identities and inverses.
+    Other properties are equivalent to VTB.
+
+    .. seealso::
+        `.VtbAlgebra`
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if type(cls._instance) is not cls:
+            cls._instance = super(TvtbAlgebra, cls).__new__(cls)
+        return cls._instance
+
+    def is_valid_dimensionality(self, d):
+        """Checks whether *d* is a valid vector dimensionality.
+
+        For TVTB all square numbers are valid dimensionalities.
+
+        Parameters
+        ----------
+        d : int
+            Dimensionality
+
+        Returns
+        -------
+        bool
+            *True*, if *d* is a valid vector dimensionality for the use with
+            the algebra.
+        """
+        if d < 1:
+            return False
+        sub_d = np.sqrt(d)
+        return sub_d * sub_d == d
+
+    def _get_sub_d(self, d):
+        sub_d = int(np.sqrt(d))
+        if sub_d * sub_d != d:
+            raise ValueError("Vector dimensionality must be a square number.")
+        return sub_d
+
+    def make_unitary(self, v):
+        sub_d = self._get_sub_d(len(v))
+        m = np.array(v.reshape((sub_d, sub_d)))
+        for i in range(1, sub_d):
+            y = -np.dot(m[:i, i:], m[i, i:])
+            A = m[:i, :i]
+            m[i, :i] = np.linalg.solve(A, y)
+        m /= np.linalg.norm(m, axis=1)[:, None]
+        m /= np.sqrt(sub_d)
+        return m.flatten()
+
+    def superpose(self, a, b):
+        return a + b
+
+    def bind(self, a, b):
+        d = len(a)
+        if len(b) != d:
+            raise ValueError("Inputs must have same length.")
+        m = self.get_binding_matrix(b)
+        return np.dot(m, a)
+
+    def invert(self, v, sidedness=ElementSidedness.TWO_SIDED):
+        """Invert vector *v*.
+
+        A vector bound to its inverse will result in the identity vector.
+
+        Parameters
+        ----------
+        v : (d,) ndarray
+            Vector to invert.
+        sidedness : ElementSidedness
+            This argument has no effect because the inverse of the TVTB algebra
+            is two-sided.
+
+        Returns
+        -------
+        (d,) ndarray
+            Inverse of vector.
+        """
+        sub_d = self._get_sub_d(len(v))
+        return v.reshape((sub_d, sub_d)).T.flatten()
+
+    def get_binding_matrix(self, v, swap_inputs=False):
+        sub_d = self._get_sub_d(len(v))
+        m = np.sqrt(sub_d) * np.kron(np.eye(sub_d), v.reshape((sub_d, sub_d)).T)
+        if swap_inputs:
+            inv_mat = self.get_inversion_matrix(len(v))
+            m = np.dot(np.dot(inv_mat, m.T), inv_mat)
+        return m
+
+    def get_inversion_matrix(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Returns the transformation matrix for inverting a vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+        sidedness : ElementSidedness
+            This argument has no effect because the inverse of the TVTB algebra
+            is two-sided.
+
+        Returns
+        -------
+        (d, d) ndarray
+            Transformation matrix to invert a vector.
+        """
+        sub_d = self._get_sub_d(d)
+        return np.eye(d).reshape(d, sub_d, sub_d).T.reshape(d, d)
+
+    def implement_superposition(self, n_neurons_per_d, d, n):
+        node = nengo.Node(size_in=d)
+        return node, n * (node,), node
+
+    def implement_binding(self, n_neurons_per_d, d, unbind_left, unbind_right):
+        net = TVTB(n_neurons_per_d, d, unbind_left, unbind_right)
+        return net, (net.input_left, net.input_right), net.output
+
+    def absorbing_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """TVTB has no absorbing element except the zero vector.
+
+        Always raises a `NotImplementedError`.
+        """
+        raise NotImplementedError("VtbAlgebra does not have any absorbing elements.")
+
+    def identity_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Return the identity element of dimensionality *d*.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+        sidedness : ElementSidedness
+            This argument has no effect because the identity of the TVTB algebra
+            is two-sided.
+
+        Returns
+        -------
+        (d,) ndarray
+            Identity element.
+        """
+        sub_d = self._get_sub_d(d)
+        return (np.eye(sub_d) / d ** 0.25).flatten()
+
+    def zero_element(self, d, sidedness=ElementSidedness.TWO_SIDED):
+        """Return the zero element of dimensionality *d*.
+
+        The zero element produces itself when bound to a different vector.
+        For VTB this is the zero vector.
+
+        Parameters
+        ----------
+        d : int
+            Vector dimensionality.
+        sidedness : ElementSidedness, optional
+            This argument has no effect because the zero element of the VTB
+            algebra is two-sided.
+
+        Returns
+        -------
+        (d,) ndarray
+            Zero element.
+        """
+        return np.zeros(d)

--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -37,12 +37,15 @@ class VtbAlgebra(AbstractAlgebra):
     .. math:: d'^2 = d.
 
     The approximate inverse :math:`y^+` for :math:`y` is permuting the elements
-    such that :math:`V_{y^+} = V_y`.
+    such that :math:`V_{y^+} = V_y^T`.
 
     Note that VTB requires the vector dimensionality to be square.
 
     The VTB binding operation is neither associative nor commutative.
     Furthermore, there are right inverses and identities only.
+    By transposing the :math:`V_y` matrix, the closely related `.TvtbAlgebra`
+    (Transposed VTB) algebra is obtained which does have two-sided identities
+    and inverses.
 
     Additional information about VTB can be found in
 
@@ -52,6 +55,9 @@ class VtbAlgebra(AbstractAlgebra):
       <https://www.mitpressjournals.org/action/showCitFormats?doi=10.1162/neco_a_01179>`_
     * `Jan Gosmann (2018). An Integrated Model of Context, Short-Term, and
       Long-Term Memory. UWSpace. <https://uwspace.uwaterloo.ca/handle/10012/13498>`_
+
+    .. seealso::
+        `.TvtbAlgebra`
     """
 
     _instance = None

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.algebras.vtb_algebra import VtbAlgebra
+from nengo_spa.algebras.tvtb_algebra import TvtbAlgebra
 
 
 class TestConfig:
@@ -27,7 +28,7 @@ class TestConfig:
     module modify these values accordingly.
     """
 
-    algebras = [HrrAlgebra(), VtbAlgebra()]
+    algebras = [HrrAlgebra(), VtbAlgebra(), TvtbAlgebra()]
 
 
 def pytest_generate_tests(metafunc):

--- a/nengo_spa/networks/__init__.py
+++ b/nengo_spa/networks/__init__.py
@@ -9,3 +9,4 @@ from .circularconvolution import CircularConvolution
 from .identity_ensemble_array import IdentityEnsembleArray
 from .matrix_multiplication import MatrixMult
 from .vtb import VTB
+from .tvtb import TVTB

--- a/nengo_spa/networks/tests/test_tvtb.py
+++ b/nengo_spa/networks/tests/test_tvtb.py
@@ -1,0 +1,55 @@
+import nengo
+import pytest
+
+import nengo_spa as spa
+from nengo_spa.algebras.tvtb_algebra import TvtbAlgebra
+from nengo_spa.networks.tvtb import TVTB
+from nengo_spa.testing import assert_sp_close
+
+
+def test_bind(Simulator, seed, rng):
+    vocab = spa.Vocabulary(16, pointer_gen=rng, algebra=TvtbAlgebra())
+    vocab.populate("A; B")
+
+    with spa.Network(seed=seed) as model:
+        vtb = TVTB(100, 16)
+        nengo.Connection(nengo.Node(vocab["A"].v), vtb.input_left)
+        nengo.Connection(nengo.Node(vocab["B"].v), vtb.input_right)
+        p = nengo.Probe(vtb.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.2)
+
+    assert_sp_close(sim.trange(), sim.data[p], vocab.parse("A*B"), skip=0.15, atol=0.3)
+
+
+@pytest.mark.parametrize("side", ("left", "right"))
+def test_unbind(Simulator, side, seed, rng):
+    vocab = spa.Vocabulary(36, pointer_gen=rng, algebra=TvtbAlgebra())
+    vocab.populate("A; B")
+
+    with spa.Network(seed=seed) as model:
+        vtb = TVTB(
+            100, 36, unbind_left=(side == "left"), unbind_right=(side == "right")
+        )
+
+        if side == "left":
+            left = nengo.Node(vocab["B"].v)
+            right = nengo.Node(vocab.parse("B*A").v)
+        elif side == "right":
+            left = nengo.Node(vocab.parse("A*B").v)
+            right = nengo.Node(vocab["B"].v)
+        else:
+            raise ValueError("Invalid 'side' value.")
+
+        nengo.Connection(left, vtb.input_left)
+        nengo.Connection(right, vtb.input_right)
+
+        p = nengo.Probe(vtb.output, synapse=0.03)
+
+    with Simulator(model) as sim:
+        sim.run(0.2)
+
+    assert_sp_close(
+        sim.trange(), sim.data[p], vocab.parse("A * B * B.rinv()"), skip=0.15, atol=0.3
+    )


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
Transposed Vector-derived Transformation Binding (TVTB) uses the same binding method as VTB, but transposes the derived matrix. This makes the identity and inverse two-sided.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
Based on #265 and PR is against that branch to get the relevant diff.

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
Mostly existing generic algebra tests, but tests for the VTB network have been copied and used to test the TVTB network.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
I'd suggest to take a look at `TvtbAlgebra` first (compare it to `VtbAlgebra`) and then look at the `TVTB` network (and compare it to the `VTB` network).

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.