### PR TITLE
Generate better SemanticPointer names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,11 @@ Release History
 - The ``~`` operator has been deprecated for the ``VtbAlgebra``. Use the
   ``rinv()`` method instead.
   (`#265 <https://github.com/nengo/nengo_spa/pull/265>`__)
+- Improved automatic names for ``SemanticPointer`` that only contain parenthesis
+  where actually needed. In addition, syntax is considered when shortening a
+  name exceeding the maximum length.
+  (`#255 <https://github.com/nengo/nengo_spa/issues/255>`__,
+  `#270 <https://github.com/nengo/nengo_spa/pull/270>`__)
 
 
 1.1.1 (November 3, 2020)

--- a/nengo_spa/ast/expr_tree.py
+++ b/nengo_spa/ast/expr_tree.py
@@ -274,6 +274,16 @@ class _LimitStrLengthVisitor:
             self.max_len = initial_max_len - 3
             return Leaf("...")
 
+    def visit_KeywordArgument(self, node):
+        initial_max_len = self.max_len
+        self.max_len -= len(str(node.value)) + 1  # 1 for assignment (=)
+        child = self.visit_node(node.children[0])
+        if self.max_len >= 0:
+            return KeywordArgument(node.value, child)
+        else:
+            self.max_len = initial_max_len - 3
+            return Leaf("...")
+
     def visit_node(self, node):
         return getattr(self, "visit_" + type(node).__name__)(node)
 

--- a/nengo_spa/ast/expr_tree.py
+++ b/nengo_spa/ast/expr_tree.py
@@ -128,3 +128,159 @@ class BinaryOperator(Node):
         if self.precedence >= rhs.precedence:
             rhs = "({})".format(rhs)
         return "{} {} {}".format(lhs, self.value, rhs)
+
+    @property
+    def lhs(self):
+        return self.children[0]
+
+    @property
+    def rhs(self):
+        return self.children[1]
+
+
+class AttributeAccess(Node):
+    __slots__ = ()
+
+    def __new__(cls, value, child):
+        return super().__new__(cls, value, precedence["x.attribute"], (child,))
+
+    def __str__(self):
+        child = self.children[0]
+        operand = str(child)
+        if self.precedence > child.precedence:
+            operand = "({})".format(operand)
+        return operand + "." + self.value
+
+
+class FunctionCall(Node):
+    __slots__ = ()
+
+    def __new__(cls, arguments, child):
+        return super().__new__(
+            cls,
+            [arg if isinstance(arg, Node) else Leaf(arg) for arg in arguments],
+            precedence["x(arguments...)"],
+            (child,),
+        )
+
+    def __str__(self):
+        child = self.children[0]
+        operand = str(child)
+        if self.precedence > child.precedence:
+            operand = "({})".format(operand)
+        return "{}({})".format(operand, ", ".join(str(arg) for arg in self.value))
+
+
+class KeywordArgument(Node):
+    __slots__ = ()
+
+    def __new__(cls, value, child):
+        return super().__new__(cls, value, 0, (child,))
+
+    def __str__(self):
+        return "{}={}".format(self.value, str(self.children[0]))
+
+
+def limit_str_length(expr_tree, max_len):
+    """Returns a modified expression tree with a string length limited to
+    approximately *max_len*."""
+
+    # General idea of the algorithm: Do an in-order traversal and keep track
+    # how much characters we may still use (max_len). When the limit is
+    # exceeded, start replacing nodes with ellipsis and re-adjust max_len to
+    # account for the characters saved through the replacement.
+
+    def visit_Leaf(node):
+        nonlocal max_len
+        if len(node.value) <= 3 or len(node.value) <= max_len:
+            max_len -= len(node.value)
+            return node
+        else:
+            max_len -= 3
+            return Leaf("...")
+
+    def visit_UnaryOperator(node):
+        nonlocal max_len
+        max_len -= len(node.value)
+        if node.precedence >= node.children[0].precedence:
+            max_len -= 2
+        return UnaryOperator(node.value, visit_node(node.children[0]))
+
+    def visit_BinaryOperator(node):
+        nonlocal max_len
+        initial_max_len = max_len
+
+        # Operator + 2 spaces + reserve 3 characters for the second operand, so
+        # that it can be at least turned into an ellipsis
+        max_len -= len(node.value) + 2 + 3
+        lhs = visit_node(node.lhs)
+        max_len += 3  # return reserved characters for the second operand
+        # Adjust for parenthesis due to operator precedence
+        if node.precedence > lhs.precedence:
+            max_len -= 2
+        if node.precedence >= node.rhs.precedence:
+            max_len -= 2
+
+        rhs = visit_node(node.rhs)
+        if max_len < 0:
+            if node.precedence >= node.rhs.precedence:
+                max_len += 2
+            max_len += len(str(rhs)) - 3
+            rhs = Leaf("...")
+        if max_len >= 0:
+            return BinaryOperator(node.value, lhs, rhs)
+        else:
+            max_len = initial_max_len - 3
+            return Leaf("...")
+
+    def visit_AttributeAccess(node):
+        nonlocal max_len
+        initial_max_len = max_len
+        max_len -= len(node.value) + 1
+        child = visit_node(node.children[0])
+        if node.precedence > child.precedence:
+            max_len -= 2
+        if max_len < 0:
+            max_len += len(str(child)) - 5
+            child = Leaf("(...)")
+        if max_len >= 0:
+            return AttributeAccess(node.value, child)
+        else:
+            max_len = initial_max_len - 3
+            return Leaf("...")
+
+    def visit_FunctionCall(node):
+        nonlocal max_len
+        initial_max_len = max_len
+        child = visit_node(node.children[0])
+        max_len -= 2  # parenthesis invoking call
+        if node.precedence > child.precedence:
+            max_len -= 2  # parenthesis around function
+
+        args = []
+        for i, arg in enumerate(node.value):
+            if i > 0:
+                max_len -= 2  # comma + space argument separator
+            arg = visit_node(arg)
+            if i > 0 and max_len < 0:
+                max_len += (
+                    len(str(args[-1])) - 3
+                )  # replacement of previous arg with ellipsis
+                max_len += (
+                    len(str(arg)) + 2
+                )  # adjust for dropped, but processed arg and separator
+                args[-1] = Leaf("...")
+            else:
+                args.append(arg)
+
+        if max_len >= 0:
+            return FunctionCall(args, child)
+        else:
+            max_len = initial_max_len - 3
+            return Leaf("...")
+
+    def visit_node(node):
+        nonlocal max_len, visit_Leaf, visit_UnaryOperator, visit_BinaryOperator, visit_AttributeAccess, visit_FunctionCall
+        return locals()["visit_" + type(node).__name__](node)
+
+    return visit_node(expr_tree)

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -200,3 +200,4 @@ def test_limit_str_length(expr_tree, max_len, expected):
     ).format(
         expr=str(expr_tree), max_len=max_len, expected=str(expected), actual=str(actual)
     )
+

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -179,6 +179,16 @@ def test_binary_operator(op):
             len("var + fn_name()") - 1,
             Leaf("var") + Leaf("..."),
         ),
+        (
+            FunctionCall([KeywordArgument("key", Leaf("value"))], Leaf("fn_name")),
+            len("fn_name(key=value)") - 1,
+            FunctionCall([KeywordArgument("key", Leaf("..."))], Leaf("fn_name")),
+        ),
+        (
+            FunctionCall([KeywordArgument("key", Leaf("value"))], Leaf("fn_name")),
+            len("fn_name(key=...)") - 1,
+            FunctionCall([Leaf("...")], Leaf("fn_name")),
+        ),
     ],
 )
 def test_limit_str_length(expr_tree, max_len, expected):

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -194,8 +194,9 @@ def test_binary_operator(op):
 )
 def test_limit_str_length(expr_tree, max_len, expected):
     actual = limit_str_length(expr_tree, max_len)
-    assert (
-        actual == expected
-    ), 'When limiting the expression "{expr}" to length {max_len}, "{expected}" is expected, but got "{actual}"'.format(
+    assert actual == expected, (
+        'When limiting the expression "{expr}" to length {max_len}, '
+        '"{expected}" is expected, but got "{actual}"'
+    ).format(
         expr=str(expr_tree), max_len=max_len, expected=str(expected), actual=str(actual)
     )

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -204,4 +204,3 @@ def test_limit_str_length(expr_tree, max_len, expected):
     ).format(
         expr=str(expr_tree), max_len=max_len, expected=str(expected), actual=str(actual)
     )
-

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -1,8 +1,12 @@
 import pytest
 
 from nengo_spa.ast.expr_tree import (
+    AttributeAccess,
     BinaryOperator,
+    FunctionCall,
+    KeywordArgument,
     Leaf,
+    limit_str_length,
     UnaryOperator,
 )
 
@@ -28,6 +32,29 @@ def test_binary_operator_str():
     assert str(BinaryOperator("-", BinaryOperator("+", a, b), c)) == "a + b - c"
 
 
+def test_attribute_access_str():
+    assert str(AttributeAccess("attr", Leaf("foo"))) == "foo.attr"
+    assert (
+        str(AttributeAccess("attr", BinaryOperator("+", Leaf("a"), Leaf("b"))))
+        == "(a + b).attr"
+    )
+
+
+def test_function_call_str():
+    assert str(FunctionCall((), Leaf("fn"))) == "fn()"
+    assert str(FunctionCall(("str1", "str2"), Leaf("fn"))) == "fn(str1, str2)"
+    assert (
+        str(FunctionCall((UnaryOperator("~", Leaf("foo")),), Leaf("fn"))) == "fn(~foo)"
+    )
+    assert (
+        str(FunctionCall((KeywordArgument("kwarg", "val"),), Leaf("fn")))
+        == "fn(kwarg=val)"
+    )
+    assert (
+        str(FunctionCall((), BinaryOperator("+", Leaf("a"), Leaf("b")))) == "(a + b)()"
+    )
+
+
 @pytest.mark.parametrize("op", ["+", "-", "~"])
 def test_unary_operator(op):
     leaf = Leaf("leaf")
@@ -41,3 +68,123 @@ def test_binary_operator(op):
     assert lhs
     assert rhs
     assert str(eval("lhs" + op + "rhs")) == "lhs {} rhs".format(op)
+
+
+@pytest.mark.parametrize(
+    "expr_tree,max_len,expected",
+    [
+        (expr_tree, len(str(expr_tree)), expr_tree)
+        for expr_tree in (
+            Leaf("foo"),
+            Leaf("not_too_long"),
+            -Leaf("foo"),
+            Leaf("a") + Leaf("b"),
+            AttributeAccess("attr", Leaf("foo")),
+            FunctionCall(("arg",), Leaf("foo")),
+        )
+    ]
+    + [
+        (Leaf("foo"), 0, Leaf("foo")),
+        (Leaf("too_long"), len("too_long") - 1, Leaf("...")),
+        (Leaf("too_long"), 3, Leaf("...")),
+        (Leaf("too_long"), 0, Leaf("...")),
+        (
+            Leaf("varA") + Leaf("varB"),
+            len("varA + varB") - 1,
+            Leaf("varA") + Leaf("..."),
+        ),
+        (Leaf("varA") + Leaf("varB"), len("varA + ..."), Leaf("varA") + Leaf("...")),
+        (Leaf("varA") + Leaf("varB"), len("varA + ...") - 1, Leaf("...") + Leaf("...")),
+        (Leaf("varA") + Leaf("varB"), 3, Leaf("...")),
+        (Leaf("a") + Leaf("b"), len("a + b") - 1, Leaf("...")),
+        (
+            (Leaf("a") + Leaf("b")) * Leaf("c"),
+            len("(a + b) * c") - 1,
+            Leaf("...") * Leaf("c"),
+        ),
+        ((Leaf("a") + Leaf("b")) * Leaf("c"), len("(a + b) * c") - 5, Leaf("...")),
+        (
+            (Leaf("a") + Leaf("b")) * Leaf("varC"),
+            len("(a + b) * varC") - 1,
+            (Leaf("a") + Leaf("b")) * Leaf("..."),
+        ),
+        (
+            Leaf("a") * (Leaf("b") + Leaf("c")),
+            len("a * (b + c)") - 1,
+            Leaf("a") * Leaf("..."),
+        ),
+        (
+            Leaf("a") * (Leaf("b") + Leaf("varC")),
+            len("a * (b + varC)") - 1,
+            Leaf("a") * (Leaf("b") + Leaf("...")),
+        ),
+        (
+            Leaf("a") + Leaf("a") * Leaf("b") + Leaf("a") * Leaf("b"),
+            len("a + a * b + a * b") - 2,
+            Leaf("a") + Leaf("a") * Leaf("b") + Leaf("..."),
+        ),
+        (
+            Leaf("a") / (Leaf("a") * Leaf("b")) / (Leaf("a") * Leaf("b")),
+            len("a / (a * b) / (a * b)") - 3,
+            Leaf("a") / (Leaf("a") * Leaf("b")) / Leaf("..."),
+        ),
+        (
+            AttributeAccess("attribute", Leaf("varA") + Leaf("varB")),
+            len("(varA + varB).attribute") - 3,
+            AttributeAccess("attribute", Leaf("(...)")),
+        ),
+        (
+            AttributeAccess("attribute", Leaf("a")),
+            len("a.attribute") - 1,
+            Leaf("..."),
+        ),
+        (FunctionCall([], Leaf("fn_name")), len("...()") - 1, Leaf("...")),
+        (
+            FunctionCall([], Leaf("fn_name")),
+            len("fn_name()") - 1,
+            Leaf("..."),
+        ),
+        (
+            FunctionCall([], Leaf("a") + Leaf("b")),
+            len("(a + b)()") - 1,
+            Leaf("..."),
+        ),
+        (
+            FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
+            len("fn_name(arg1, arg2)") - 1,
+            FunctionCall(["arg1", "..."], Leaf("fn_name")),
+        ),
+        (
+            FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
+            len("fn_name(arg1, arg2)") - 2,
+            FunctionCall(["..."], Leaf("fn_name")),
+        ),
+        (
+            FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
+            len("fn_name(arg1, arg2)") - 8,
+            Leaf("..."),
+        ),
+        (
+            FunctionCall(["arg1", "arg2"], Leaf("a") + Leaf("b")),
+            len("(a + b)(arg1, arg2)") - 1,
+            FunctionCall(["arg1", "..."], Leaf("a") + Leaf("b")),
+        ),
+        (
+            FunctionCall([Leaf("arg1") + Leaf("arg2")], Leaf("fn_name")),
+            len("fn_name(arg1 + arg2)") - 1,
+            FunctionCall([Leaf("arg1") + Leaf("...")], Leaf("fn_name")),
+        ),
+        (
+            Leaf("var") + FunctionCall([], Leaf("fn_name")),
+            len("var + fn_name()") - 1,
+            Leaf("var") + Leaf("..."),
+        ),
+    ],
+)
+def test_limit_str_length(expr_tree, max_len, expected):
+    actual = limit_str_length(expr_tree, max_len)
+    assert (
+        actual == expected
+    ), 'When limiting the expression "{expr}" to length {max_len}, "{expected}" is expected, but got "{actual}"'.format(
+        expr=str(expr_tree), max_len=max_len, expected=str(expected), actual=str(actual)
+    )

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -3,6 +3,7 @@ import pytest
 from nengo_spa.ast.expr_tree import (
     AttributeAccess,
     BinaryOperator,
+    EllipsisLeaf,
     FunctionCall,
     KeywordArgument,
     Leaf,
@@ -85,84 +86,84 @@ def test_binary_operator(op):
     ]
     + [
         (Leaf("foo"), 0, Leaf("foo")),
-        (Leaf("too_long"), len("too_long") - 1, Leaf("...")),
-        (Leaf("too_long"), 3, Leaf("...")),
-        (Leaf("too_long"), 0, Leaf("...")),
+        (Leaf("too_long"), len("too_long") - 1, EllipsisLeaf()),
+        (Leaf("too_long"), 3, EllipsisLeaf()),
+        (Leaf("too_long"), 0, EllipsisLeaf()),
         (
             Leaf("varA") + Leaf("varB"),
             len("varA + varB") - 1,
-            Leaf("varA") + Leaf("..."),
+            Leaf("varA") + EllipsisLeaf(),
         ),
-        (Leaf("varA") + Leaf("varB"), len("varA + ..."), Leaf("varA") + Leaf("...")),
-        (Leaf("varA") + Leaf("varB"), len("varA + ...") - 1, Leaf("...") + Leaf("...")),
-        (Leaf("varA") + Leaf("varB"), 3, Leaf("...")),
-        (Leaf("a") + Leaf("b"), len("a + b") - 1, Leaf("...")),
+        (Leaf("varA") + Leaf("varB"), len("varA + ..."), Leaf("varA") + EllipsisLeaf()),
+        (
+            Leaf("varA") + Leaf("varB"),
+            len("varA + ...") - 1,
+            EllipsisLeaf() + EllipsisLeaf(),
+        ),
+        (Leaf("varA") + Leaf("varB"), 3, EllipsisLeaf()),
+        (Leaf("a") + Leaf("b"), len("a + b") - 1, EllipsisLeaf()),
         (
             (Leaf("a") + Leaf("b")) * Leaf("c"),
             len("(a + b) * c") - 1,
-            Leaf("...") * Leaf("c"),
+            EllipsisLeaf() * Leaf("c"),
         ),
-        ((Leaf("a") + Leaf("b")) * Leaf("c"), len("(a + b) * c") - 5, Leaf("...")),
+        ((Leaf("a") + Leaf("b")) * Leaf("c"), len("(a + b) * c") - 5, EllipsisLeaf()),
         (
             (Leaf("a") + Leaf("b")) * Leaf("varC"),
             len("(a + b) * varC") - 1,
-            (Leaf("a") + Leaf("b")) * Leaf("..."),
+            (Leaf("a") + Leaf("b")) * EllipsisLeaf(),
         ),
         (
             Leaf("a") * (Leaf("b") + Leaf("c")),
             len("a * (b + c)") - 1,
-            Leaf("a") * Leaf("..."),
+            Leaf("a") * EllipsisLeaf(),
         ),
         (
             Leaf("a") * (Leaf("b") + Leaf("varC")),
             len("a * (b + varC)") - 1,
-            Leaf("a") * (Leaf("b") + Leaf("...")),
+            Leaf("a") * (Leaf("b") + EllipsisLeaf()),
         ),
         (
             Leaf("a") + Leaf("a") * Leaf("b") + Leaf("a") * Leaf("b"),
             len("a + a * b + a * b") - 2,
-            Leaf("a") + Leaf("a") * Leaf("b") + Leaf("..."),
+            Leaf("a") + Leaf("a") * Leaf("b") + EllipsisLeaf(),
         ),
         (
             Leaf("a") / (Leaf("a") * Leaf("b")) / (Leaf("a") * Leaf("b")),
             len("a / (a * b) / (a * b)") - 3,
-            Leaf("a") / (Leaf("a") * Leaf("b")) / Leaf("..."),
+            Leaf("a") / (Leaf("a") * Leaf("b")) / EllipsisLeaf(),
         ),
         (
             AttributeAccess("attribute", Leaf("varA") + Leaf("varB")),
             len("(varA + varB).attribute") - 3,
-            AttributeAccess("attribute", Leaf("(...)")),
+            AttributeAccess("attribute", EllipsisLeaf("(...)")),
         ),
         (
             AttributeAccess("attribute", Leaf("a")),
             len("a.attribute") - 1,
-            Leaf("..."),
+            EllipsisLeaf(),
         ),
-        (FunctionCall([], Leaf("fn_name")), len("...()") - 1, Leaf("...")),
-        (
-            FunctionCall([], Leaf("fn_name")),
-            len("fn_name()") - 1,
-            Leaf("..."),
-        ),
+        (FunctionCall([], Leaf("fn_name")), len("...()") - 1, EllipsisLeaf()),
+        (FunctionCall([], Leaf("fn_name")), len("fn_name()") - 1, EllipsisLeaf(),),
         (
             FunctionCall([], Leaf("a") + Leaf("b")),
             len("(a + b)()") - 1,
-            Leaf("..."),
+            EllipsisLeaf(),
         ),
         (
             FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
             len("fn_name(arg1, arg2)") - 1,
-            FunctionCall(["arg1", "..."], Leaf("fn_name")),
+            FunctionCall(["arg1", EllipsisLeaf()], Leaf("fn_name")),
         ),
         (
             FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
             len("fn_name(arg1, arg2)") - 2,
-            FunctionCall(["..."], Leaf("fn_name")),
+            FunctionCall([EllipsisLeaf()], Leaf("fn_name")),
         ),
         (
             FunctionCall(["arg1", "arg2"], Leaf("fn_name")),
             len("fn_name(arg1, arg2)") - 8,
-            Leaf("..."),
+            EllipsisLeaf(),
         ),
         (
             FunctionCall(["arg1", "arg2"], Leaf("a") + Leaf("b")),
@@ -172,7 +173,7 @@ def test_binary_operator(op):
         (
             FunctionCall([Leaf("arg1") + Leaf("arg2")], Leaf("fn_name")),
             len("fn_name(arg1 + arg2)") - 1,
-            FunctionCall([Leaf("arg1") + Leaf("...")], Leaf("fn_name")),
+            FunctionCall([Leaf("arg1") + EllipsisLeaf()], Leaf("fn_name")),
         ),
         (
             Leaf("var") + FunctionCall([], Leaf("fn_name")),
@@ -182,12 +183,12 @@ def test_binary_operator(op):
         (
             FunctionCall([KeywordArgument("key", Leaf("value"))], Leaf("fn_name")),
             len("fn_name(key=value)") - 1,
-            FunctionCall([KeywordArgument("key", Leaf("..."))], Leaf("fn_name")),
+            FunctionCall([KeywordArgument("key", EllipsisLeaf())], Leaf("fn_name")),
         ),
         (
             FunctionCall([KeywordArgument("key", Leaf("value"))], Leaf("fn_name")),
             len("fn_name(key=...)") - 1,
-            FunctionCall([Leaf("...")], Leaf("fn_name")),
+            FunctionCall([EllipsisLeaf()], Leaf("fn_name")),
         ),
     ],
 )

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -144,7 +144,11 @@ def test_binary_operator(op):
             EllipsisLeaf(),
         ),
         (FunctionCall([], Leaf("fn_name")), len("...()") - 1, EllipsisLeaf()),
-        (FunctionCall([], Leaf("fn_name")), len("fn_name()") - 1, EllipsisLeaf(),),
+        (
+            FunctionCall([], Leaf("fn_name")),
+            len("fn_name()") - 1,
+            EllipsisLeaf(),
+        ),
         (
             FunctionCall([], Leaf("a") + Leaf("b")),
             len("(a + b)()") - 1,

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -106,7 +106,7 @@ class SemanticPointer(Fixed):
         if isinstance(other, SemanticPointer):
             other_expr_tree = other._expr_tree
         else:
-            other_expr_tree = Leaf(str(other))  # FIXME what is this for?
+            other_expr_tree = Leaf(str(other))
         self_expr_tree = self._expr_tree
         if self_expr_tree and other_expr_tree:
             if swap:

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -390,14 +390,14 @@ def test_name():
         )
     )
 
-    assert (-a).name == "-(a)"
-    assert (~a).name == "~(a)"
-    assert a.normalized().name == "(a).normalized()"
-    assert a.unitary().name == "(a).unitary()"
-    assert (a + b).name == "(a)+(b)"
-    assert (a * b).name == "(a)*(b)"
-    assert (2.0 * a).name == "(2.0)*(a)"
-    assert (a / 2.0).name == "(a)/(2.0)"
+    assert (-a).name == "-a"
+    assert (~a).name == "~a"
+    assert a.normalized().name == "a.normalized()"
+    assert a.unitary().name == "a.unitary()"
+    assert (a + b).name == "a + b"
+    assert (a * b).name == "a * b"
+    assert (2.0 * a).name == "2.0 * a"
+    assert (a / 2.0).name == "a / 2.0"
 
     assert (a + unnamed).name is None
     assert (a * unnamed).name is None
@@ -405,7 +405,8 @@ def test_name():
     # check that names that blow up exponentially in length are truncated
     for i in range(10):
         a += a * b
-    assert len(a.name) == a.MAX_NAME
+    assert len(a.name) <= a.MAX_NAME
+    assert a.name.startswith("a + a * b + (a + a * b) * b")
     assert a.name.endswith("...")
 
 

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -365,4 +365,4 @@ def test_pointer_names():
     v.populate("A; B")
 
     assert v["A"].name == "A"
-    assert v.parse("A*B").name == "(A)*(B)"
+    assert v.parse("A*B").name == "A * B"


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Instead of immediately constructing a string for the SemanticPointer
name, this uses the expr_tree classes to construct a syntax tree.
This enables keeping track of operation precedence and allows to
render a name with only the necessary parenthesis increasing the
readability of SemanticPointer names.

Furthermore, this implements a visitor for this syntax tree to limit the
rendered length while preserving correctness of the parenthesis.

Closes #255.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
* added unit tests
* modified the test for maximum name length accordingly

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Lengthy (more than 150 lines changed or changes are complicated)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you still plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

* [x] Handle `KeywordArgument` when limiting length