### PR TITLE
Use isort import order

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,8 +7,9 @@ import os
 import sys
 
 try:
-    import nengo_spa
     import nengo_sphinx_theme
+
+    import nengo_spa
 
     assert nengo_sphinx_theme
 except ImportError:

--- a/docs/examples/associative-memory.ipynb
+++ b/docs/examples/associative-memory.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "A theoretical explanation on how the associative memory is implemented in NEF is\n",
     "available in [Stewart et al.\n",
-    "2010](http://compneuro.uwaterloo.ca/files/publications/stewart.2011.pdf)."
+    "2011](http://compneuro.uwaterloo.ca/publications/stewart2011.html)."
    ]
   },
   {

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -1,25 +1,24 @@
 from nengo_spa import version
-
 from nengo_spa.action_selection import ActionSelection
 from nengo_spa.ast.symbolic import sym
-from nengo_spa.operators import dot, reinterpret, translate
 from nengo_spa.examine import pairs, similarity, text
 from nengo_spa.modules import (
     AssociativeMemory,
-    IAAssocMem,
-    ThresholdingAssocMem,
-    WTAAssocMem,
     BasalGanglia,
     Bind,
     Compare,
+    IAAssocMem,
     Product,
     Scalar,
     State,
     Superposition,
     Thalamus,
+    ThresholdingAssocMem,
     Transcode,
+    WTAAssocMem,
 )
-from nengo_spa.network import create_inhibit_node, ifmax, Network
+from nengo_spa.network import Network, create_inhibit_node, ifmax
+from nengo_spa.operators import dot, reinterpret, translate
 from nengo_spa.semantic_pointer import SemanticPointer
 from nengo_spa.vector_generation import (
     AxisAlignedVectors,
@@ -29,7 +28,6 @@ from nengo_spa.vector_generation import (
     UnitLengthVectors,
 )
 from nengo_spa.vocabulary import Vocabulary
-
 
 __copyright__ = "2013-2020, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"

--- a/nengo_spa/action_selection.py
+++ b/nengo_spa/action_selection.py
@@ -1,12 +1,12 @@
 """Implementation of action syntax."""
 
-from collections.abc import Mapping
 from collections import OrderedDict
+from collections.abc import Mapping
 
 import nengo
 
 from nengo_spa.ast import dynamic
-from nengo_spa.connectors import input_vocab_registry, ModuleInput, RoutedConnection
+from nengo_spa.connectors import ModuleInput, RoutedConnection, input_vocab_registry
 from nengo_spa.exceptions import SpaActionSelectionError, SpaTypeError
 from nengo_spa.types import TScalar
 

--- a/nengo_spa/algebras/__init__.py
+++ b/nengo_spa/algebras/__init__.py
@@ -2,5 +2,5 @@
 
 from .base import AbstractAlgebra, ElementSidedness
 from .hrr_algebra import HrrAlgebra
-from .vtb_algebra import VtbAlgebra
 from .tvtb_algebra import TvtbAlgebra
+from .vtb_algebra import VtbAlgebra

--- a/nengo_spa/algebras/base.py
+++ b/nengo_spa/algebras/base.py
@@ -1,6 +1,6 @@
+import warnings
 from abc import ABCMeta
 from enum import Enum
-import warnings
 
 
 class ElementSidedness(Enum):

--- a/nengo_spa/ast/base.py
+++ b/nengo_spa/ast/base.py
@@ -1,7 +1,7 @@
 """Basic classes for abstract syntax trees (ASTs) in NengoSPA."""
 
 from nengo_spa.typechecks import is_array
-from nengo_spa.types import coerce_types, TAnyVocab, TVocabulary
+from nengo_spa.types import TAnyVocab, TVocabulary, coerce_types
 
 
 def infer_types(*nodes):

--- a/nengo_spa/ast/dynamic.py
+++ b/nengo_spa/ast/dynamic.py
@@ -4,12 +4,11 @@ import nengo
 import numpy as np
 
 from nengo_spa.algebras.base import ElementSidedness
-from nengo_spa.ast.base import infer_types, Node, TypeCheckedBinaryOp
+from nengo_spa.ast.base import Node, TypeCheckedBinaryOp, infer_types
 from nengo_spa.ast.symbolic import Fixed, FixedScalar, Symbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.typechecks import is_number
-from nengo_spa.types import TAnyVocab, TScalar, TAnyVocabOfDim, TVocabulary
-
+from nengo_spa.types import TAnyVocab, TAnyVocabOfDim, TScalar, TVocabulary
 
 BasalGangliaRealization = None
 BindRealization = None

--- a/nengo_spa/ast/expr_tree.py
+++ b/nengo_spa/ast/expr_tree.py
@@ -2,7 +2,6 @@
 
 from collections import namedtuple
 
-
 # Reference precedence table:
 # https://docs.python.org/3/reference/expressions.html
 precedence = {

--- a/nengo_spa/ast/symbolic.py
+++ b/nengo_spa/ast/symbolic.py
@@ -6,7 +6,7 @@ import nengo
 import numpy as np
 
 from nengo_spa.ast import expr_tree
-from nengo_spa.ast.base import infer_types, Fixed, TypeCheckedBinaryOp
+from nengo_spa.ast.base import Fixed, TypeCheckedBinaryOp, infer_types
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.semantic_pointer import SemanticPointer
 from nengo_spa.typechecks import is_number

--- a/nengo_spa/ast/tests/test_dynamic.py
+++ b/nengo_spa/ast/tests/test_dynamic.py
@@ -2,8 +2,8 @@ import sys
 
 import nengo
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 import nengo_spa as spa
 from nengo_spa.ast.symbolic import PointerSymbol

--- a/nengo_spa/ast/tests/test_expr_tree.py
+++ b/nengo_spa/ast/tests/test_expr_tree.py
@@ -7,8 +7,8 @@ from nengo_spa.ast.expr_tree import (
     FunctionCall,
     KeywordArgument,
     Leaf,
-    limit_str_length,
     UnaryOperator,
+    limit_str_length,
 )
 
 

--- a/nengo_spa/ast/tests/test_symbolic.py
+++ b/nengo_spa/ast/tests/test_symbolic.py
@@ -2,8 +2,8 @@ import sys
 
 import nengo
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 
 import nengo_spa as spa
 from nengo_spa import sym

--- a/nengo_spa/conftest.py
+++ b/nengo_spa/conftest.py
@@ -13,8 +13,8 @@ except ImportError:
 
 
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
-from nengo_spa.algebras.vtb_algebra import VtbAlgebra
 from nengo_spa.algebras.tvtb_algebra import TvtbAlgebra
+from nengo_spa.algebras.vtb_algebra import VtbAlgebra
 
 
 class TestConfig:

--- a/nengo_spa/connectors.py
+++ b/nengo_spa/connectors.py
@@ -3,7 +3,7 @@ import weakref
 import nengo
 import numpy as np
 
-from nengo_spa.ast.base import Node, infer_types, Fixed
+from nengo_spa.ast.base import Fixed, Node, infer_types
 from nengo_spa.ast.dynamic import ModuleOutput
 from nengo_spa.ast.symbolic import FixedScalar
 from nengo_spa.exceptions import SpaTypeError

--- a/nengo_spa/examine.py
+++ b/nengo_spa/examine.py
@@ -2,9 +2,8 @@
 
 from itertools import combinations
 
-import numpy as np
-
 import nengo.utils.numpy as npext
+import numpy as np
 from nengo.exceptions import ValidationError
 
 from nengo_spa.semantic_pointer import SemanticPointer

--- a/nengo_spa/modules/associative_memory.py
+++ b/nengo_spa/modules/associative_memory.py
@@ -3,12 +3,12 @@
 See :doc:`examples/associative_memory` for an introduction and examples.
 """
 import nengo
+import numpy as np
 from nengo.exceptions import ValidationError
 from nengo.utils.network import with_self
-import numpy as np
 
 from nengo_spa.network import Network
-from nengo_spa.networks.selection import IA, Thresholding, WTA
+from nengo_spa.networks.selection import IA, WTA, Thresholding
 from nengo_spa.vocabulary import VocabularyOrDimParam
 
 

--- a/nengo_spa/modules/basalganglia.py
+++ b/nengo_spa/modules/basalganglia.py
@@ -1,10 +1,10 @@
 import warnings
 
 import nengo
+import numpy as np
 from nengo.networks.ensemblearray import EnsembleArray
 from nengo.params import Default, IntParam, NumberParam
 from nengo.synapses import Lowpass, SynapseParam
-import numpy as np
 
 from nengo_spa.network import Network
 

--- a/nengo_spa/modules/compare.py
+++ b/nengo_spa/modules/compare.py
@@ -1,6 +1,6 @@
 import nengo
-from nengo.params import Default, IntParam
 import numpy as np
+from nengo.params import Default, IntParam
 
 from nengo_spa.network import Network
 from nengo_spa.vocabulary import VocabularyOrDimParam

--- a/nengo_spa/modules/tests/test_associative_memory.py
+++ b/nengo_spa/modules/tests/test_associative_memory.py
@@ -1,18 +1,17 @@
 import nengo
-from nengo.exceptions import ValidationError
 import numpy as np
 import pytest
+from nengo.exceptions import ValidationError
 
 import nengo_spa as spa
 from nengo_spa import Vocabulary
+from nengo_spa.examine import similarity
 from nengo_spa.modules.associative_memory import (
+    IAAssocMem,
     ThresholdingAssocMem,
     WTAAssocMem,
-    IAAssocMem,
 )
-from nengo_spa.examine import similarity
 from nengo_spa.testing import assert_sp_close
-
 
 filtered_step_fn = lambda x: np.maximum(1.0 - np.exp(-15.0 * x), 0.0)
 

--- a/nengo_spa/modules/tests/test_basalganglia.py
+++ b/nengo_spa/modules/tests/test_basalganglia.py
@@ -1,7 +1,7 @@
+import nengo
 import numpy as np
 import pytest
 
-import nengo
 import nengo_spa as spa
 
 

--- a/nengo_spa/modules/tests/test_bind.py
+++ b/nengo_spa/modules/tests/test_bind.py
@@ -1,6 +1,6 @@
 import nengo
-from nengo.utils.numpy import rms
 import pytest
+from nengo.utils.numpy import rms
 
 import nengo_spa as spa
 from nengo_spa.testing import assert_sp_close

--- a/nengo_spa/modules/tests/test_compare.py
+++ b/nengo_spa/modules/tests/test_compare.py
@@ -1,4 +1,5 @@
 import nengo
+
 import nengo_spa as spa
 
 

--- a/nengo_spa/modules/tests/test_cortical.py
+++ b/nengo_spa/modules/tests/test_cortical.py
@@ -1,7 +1,7 @@
+import nengo
 import numpy as np
 import pytest
 
-import nengo
 import nengo_spa as spa
 
 

--- a/nengo_spa/modules/tests/test_state.py
+++ b/nengo_spa/modules/tests/test_state.py
@@ -1,6 +1,6 @@
+import nengo
 import numpy as np
 
-import nengo
 import nengo_spa as spa
 
 

--- a/nengo_spa/modules/tests/test_thalamus.py
+++ b/nengo_spa/modules/tests/test_thalamus.py
@@ -1,7 +1,6 @@
-import pytest
-
 import nengo
 import numpy as np
+import pytest
 
 import nengo_spa as spa
 

--- a/nengo_spa/modules/tests/test_transcode.py
+++ b/nengo_spa/modules/tests/test_transcode.py
@@ -1,8 +1,8 @@
 import nengo
-from nengo.exceptions import ValidationError
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
+from nengo.exceptions import ValidationError
+from numpy.testing import assert_almost_equal
 
 import nengo_spa as spa
 from nengo_spa.modules.transcode import Transcode

--- a/nengo_spa/modules/thalamus.py
+++ b/nengo_spa/modules/thalamus.py
@@ -1,6 +1,5 @@
-import numpy as np
-
 import nengo
+import numpy as np
 from nengo.dists import Uniform
 from nengo.params import Default, IntParam, NumberParam
 from nengo.synapses import Lowpass, SynapseParam

--- a/nengo_spa/modules/transcode.py
+++ b/nengo_spa/modules/transcode.py
@@ -1,9 +1,9 @@
 import nengo
+import numpy as np
 from nengo.config import Default
 from nengo.exceptions import ValidationError
 from nengo.params import IntParam, Parameter
 from nengo.utils.stdlib import checked_call
-import numpy as np
 
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.network import Network

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -2,16 +2,16 @@ import inspect
 import weakref
 
 import nengo
-from nengo.config import Config, SupportDefaultsMixin
 import numpy as np
+from nengo.config import Config, SupportDefaultsMixin
 
 from nengo_spa.action_selection import ifmax as actions_ifmax
 from nengo_spa.ast.base import Noop
 from nengo_spa.connectors import (
+    SpaOperatorMixin,
     as_ast_node,
     input_vocab_registry,
     output_vocab_registry,
-    SpaOperatorMixin,
 )
 from nengo_spa.types import TScalar
 from nengo_spa.vocabulary import VocabularyMap, VocabularyMapParam

--- a/nengo_spa/networks/__init__.py
+++ b/nengo_spa/networks/__init__.py
@@ -8,5 +8,5 @@ from . import selection
 from .circularconvolution import CircularConvolution
 from .identity_ensemble_array import IdentityEnsembleArray
 from .matrix_multiplication import MatrixMult
-from .vtb import VTB
 from .tvtb import TVTB
+from .vtb import VTB

--- a/nengo_spa/networks/circularconvolution.py
+++ b/nengo_spa/networks/circularconvolution.py
@@ -1,6 +1,5 @@
-import numpy as np
-
 import nengo
+import numpy as np
 from nengo.exceptions import ValidationError
 from nengo.networks.product import Product
 

--- a/nengo_spa/networks/identity_ensemble_array.py
+++ b/nengo_spa/networks/identity_ensemble_array.py
@@ -1,9 +1,9 @@
 import warnings
 
 import nengo
+import numpy as np
 from nengo.exceptions import ValidationError
 from nengo.utils.network import with_self
-import numpy as np
 
 from nengo_spa.typechecks import is_iterable
 

--- a/nengo_spa/networks/tests/test_circularconv.py
+++ b/nengo_spa/networks/tests/test_circularconv.py
@@ -1,7 +1,6 @@
+import nengo
 import numpy as np
 import pytest
-
-import nengo
 from nengo.utils.numpy import rms
 
 import nengo_spa

--- a/nengo_spa/networks/tests/test_identity_ensemble_array.py
+++ b/nengo_spa/networks/tests/test_identity_ensemble_array.py
@@ -1,12 +1,12 @@
 import nengo
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
+from numpy.testing import assert_almost_equal
 
 from nengo_spa.networks.identity_ensemble_array import IdentityEnsembleArray
 from nengo_spa.semantic_pointer import Identity, SemanticPointer
-from nengo_spa.vector_generation import UnitLengthVectors
 from nengo_spa.testing import assert_sp_close
+from nengo_spa.vector_generation import UnitLengthVectors
 
 
 @pytest.mark.parametrize("pointer", [Identity, UnitLengthVectors])

--- a/nengo_spa/networks/tests/test_selection.py
+++ b/nengo_spa/networks/tests/test_selection.py
@@ -1,8 +1,8 @@
+import nengo
 import numpy as np
 from numpy.testing import assert_allclose
 
-import nengo
-from nengo_spa.networks.selection import IA, Thresholding, WTA
+from nengo_spa.networks.selection import IA, WTA, Thresholding
 
 
 def test_ia(Simulator, plt, seed):

--- a/nengo_spa/networks/tvtb.py
+++ b/nengo_spa/networks/tvtb.py
@@ -1,7 +1,7 @@
 import nengo
+import numpy as np
 from nengo.dists import CosineSimilarity
 from nengo.exceptions import ValidationError
-import numpy as np
 
 from nengo_spa.networks.matrix_multiplication import MatrixMult
 

--- a/nengo_spa/networks/vtb.py
+++ b/nengo_spa/networks/vtb.py
@@ -1,7 +1,7 @@
 import nengo
+import numpy as np
 from nengo.dists import CosineSimilarity
 from nengo.exceptions import ValidationError
-import numpy as np
 
 from nengo_spa.networks.matrix_multiplication import MatrixMult
 

--- a/nengo_spa/semantic_pointer.py
+++ b/nengo_spa/semantic_pointer.py
@@ -1,18 +1,18 @@
 import nengo
-from nengo.exceptions import ValidationError
 import numpy as np
+from nengo.exceptions import ValidationError
 
 from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
-from nengo_spa.ast.base import Fixed, infer_types, TypeCheckedBinaryOp
+from nengo_spa.ast.base import Fixed, TypeCheckedBinaryOp, infer_types
 from nengo_spa.ast.expr_tree import (
     AttributeAccess,
     BinaryOperator,
     FunctionCall,
     Leaf,
-    limit_str_length,
     Node,
     UnaryOperator,
+    limit_str_length,
 )
 from nengo_spa.typechecks import is_array, is_array_like, is_number
 from nengo_spa.types import TAnyVocab, TScalar, TVocabulary

--- a/nengo_spa/tests/test_action_selection.py
+++ b/nengo_spa/tests/test_action_selection.py
@@ -1,7 +1,7 @@
 import nengo
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 import nengo_spa as spa
 from nengo_spa.action_selection import ActionSelection

--- a/nengo_spa/tests/test_examples.py
+++ b/nengo_spa/tests/test_examples.py
@@ -1,8 +1,7 @@
 import os
 
-import pytest
 import _pytest.capture
-
+import pytest
 from nbformat import read as read_nb
 from nengo.utils.stdlib import execfile
 

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -1,11 +1,11 @@
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
-
 import nengo
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.examine import similarity
+from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.network import create_inhibit_node
 from nengo_spa.vocabulary import VocabularyMap
 

--- a/nengo_spa/tests/test_semantic_pointer.py
+++ b/nengo_spa/tests/test_semantic_pointer.py
@@ -1,10 +1,10 @@
 import sys
 
 import nengo
-from nengo.exceptions import NengoWarning, ValidationError
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
+from nengo.exceptions import NengoWarning, ValidationError
+from numpy.testing import assert_equal
 
 import nengo_spa as spa
 from nengo_spa.algebras.base import AbstractAlgebra, ElementSidedness
@@ -12,9 +12,9 @@ from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.ast.symbolic import PointerSymbol
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.semantic_pointer import AbsorbingElement, Identity, SemanticPointer, Zero
-from nengo_spa.vector_generation import UnitLengthVectors
 from nengo_spa.testing import assert_sp_close
 from nengo_spa.types import TVocabulary
+from nengo_spa.vector_generation import UnitLengthVectors
 from nengo_spa.vocabulary import Vocabulary
 
 

--- a/nengo_spa/tests/test_types.py
+++ b/nengo_spa/tests/test_types.py
@@ -2,12 +2,12 @@ import pytest
 
 from nengo_spa.exceptions import SpaTypeError
 from nengo_spa.types import (
-    coerce_types,
     TAnyVocab,
-    TScalar,
     TAnyVocabOfDim,
+    TScalar,
     TVocabulary,
     Type,
+    coerce_types,
 )
 from nengo_spa.vocabulary import Vocabulary
 

--- a/nengo_spa/tests/test_vector_generation.py
+++ b/nengo_spa/tests/test_vector_generation.py
@@ -7,8 +7,8 @@ from nengo_spa.vector_generation import (
     AxisAlignedVectors,
     ExpectedUnitLengthVectors,
     OrthonormalVectors,
-    UnitLengthVectors,
     UnitaryVectors,
+    UnitLengthVectors,
 )
 
 

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
-from nengo.exceptions import NengoWarning, ValidationError
 import nengo.solvers
 import numpy as np
-from numpy.testing import assert_equal
 import pytest
+from nengo.exceptions import NengoWarning, ValidationError
+from numpy.testing import assert_equal
 
 from nengo_spa import SemanticPointer, Vocabulary
 from nengo_spa.algebras import HrrAlgebra, VtbAlgebra
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.vector_generation import AxisAlignedVectors
 from nengo_spa.vocabulary import (
-    special_sps,
     VocabularyMap,
     VocabularyMapParam,
     VocabularyOrDimParam,
+    special_sps,
 )
 
 

--- a/nengo_spa/vocabulary.py
+++ b/nengo_spa/vocabulary.py
@@ -1,19 +1,18 @@
-from collections.abc import Mapping
-from keyword import iskeyword
 import re
 import warnings
+from collections.abc import Mapping
+from keyword import iskeyword
 
 import nengo
-from nengo.exceptions import NengoWarning, ValidationError
 import numpy as np
+from nengo.exceptions import NengoWarning, ValidationError
 
 from nengo_spa import semantic_pointer
 from nengo_spa.algebras.hrr_algebra import HrrAlgebra
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.semantic_pointer import AbsorbingElement, Identity, Zero
-from nengo_spa.typechecks import is_number, is_integer, is_iterable
+from nengo_spa.typechecks import is_integer, is_iterable, is_number
 from nengo_spa.vector_generation import UnitLengthVectors
-
 
 valid_sp_regex = re.compile("^[A-Z][_a-zA-Z0-9]*$")
 special_sps = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,10 @@ exclude = __init__.py, compat.py
 ignore = E123,E133,E203,E226,E241,E242,E501,E731,F401,W503
 max-complexity = 10
 
+[isort]
+profile = black
+src_paths = nengo_spa
+
 [tool:pytest]
 norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots
 markers =


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->
Makes the build green again.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none (except that they will update their import order if they change imports)

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
CI build

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
isort is configured in setup.cfg (NengoSPA isn't using a pyproject.toml yet).

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [n/a] I have run the test suite locally and all tests passed.
