### PR TITLE
New vector generators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Release History
 
 - Support for (fractional) binding powers and the notion of signs in algebras.
   (`#271 <https://github.com/nengo/nengo_spa/pull/271>`__)
+- ``VectorsWithProperties`` vector generator.
+  (`#284 <https://github.com/nengo/nengo_spa/issues/284>`__,
+  `#285 <https://github.com/nengo/nengo_spa/pull/285>`__)
 
 **Removed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,8 @@ Release History
 
 - Support for (fractional) binding powers and the notion of signs in algebras.
   (`#271 <https://github.com/nengo/nengo_spa/pull/271>`__)
-- ``VectorsWithProperties`` vector generator.
+- ``EquallySpacedPositiveUnitaryHrrVectors`` and ``VectorsWithProperties``
+  vector generators.
   (`#284 <https://github.com/nengo/nengo_spa/issues/284>`__,
   `#285 <https://github.com/nengo/nengo_spa/pull/285>`__)
 

--- a/docs/modules/nengo_spa.vector_generation.rst
+++ b/docs/modules/nengo_spa.vector_generation.rst
@@ -13,4 +13,5 @@ nengo\_spa\.vector_generation
       UnitaryVectors
       OrthonormalVectors
       ExpectedUnitLengthVectors
+      EquallySpacedPositiveUnitaryHrrVectors
       VectorsWithProperties

--- a/docs/modules/nengo_spa.vector_generation.rst
+++ b/docs/modules/nengo_spa.vector_generation.rst
@@ -13,3 +13,4 @@ nengo\_spa\.vector_generation
       UnitaryVectors
       OrthonormalVectors
       ExpectedUnitLengthVectors
+      VectorsWithProperties

--- a/docs/modules/nengo_spa.vector_generation.rst
+++ b/docs/modules/nengo_spa.vector_generation.rst
@@ -9,9 +9,9 @@ nengo\_spa\.vector_generation
    .. autosummary::
 
       AxisAlignedVectors
+      EquallySpacedPositiveUnitaryHrrVectors
+      ExpectedUnitLengthVectors
       UnitLengthVectors
       UnitaryVectors
       OrthonormalVectors
-      ExpectedUnitLengthVectors
-      EquallySpacedPositiveUnitaryHrrVectors
       VectorsWithProperties

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -26,6 +26,7 @@ from nengo_spa.vector_generation import (
     OrthonormalVectors,
     UnitaryVectors,
     UnitLengthVectors,
+    VectorsWithProperties,
 )
 from nengo_spa.vocabulary import Vocabulary
 

--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -22,6 +22,7 @@ from nengo_spa.operators import dot, reinterpret, translate
 from nengo_spa.semantic_pointer import SemanticPointer
 from nengo_spa.vector_generation import (
     AxisAlignedVectors,
+    EquallySpacedPositiveUnitaryHrrVectors,
     ExpectedUnitLengthVectors,
     OrthonormalVectors,
     UnitaryVectors,

--- a/nengo_spa/modules/tests/test_cortical.py
+++ b/nengo_spa/modules/tests/test_cortical.py
@@ -51,9 +51,10 @@ def test_translate(Simulator, seed):
         model.buffer2 = spa.State(vocab=32)
 
         spa.sym.A >> model.buffer1
-        spa.translate(
-            model.buffer1, model.buffer2.vocab, populate=True
-        ) >> model.buffer2
+        (
+            spa.translate(model.buffer1, model.buffer2.vocab, populate=True)
+            >> model.buffer2
+        )
 
         p = nengo.Probe(model.buffer2.output, synapse=0.03)
 

--- a/nengo_spa/tests/test_vector_generation.py
+++ b/nengo_spa/tests/test_vector_generation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from nengo_spa.algebras import HrrAlgebra
+from nengo_spa.algebras import CommonProperties, HrrAlgebra
 from nengo_spa.semantic_pointer import SemanticPointer
 from nengo_spa.vector_generation import (
     AxisAlignedVectors,
@@ -9,6 +9,7 @@ from nengo_spa.vector_generation import (
     OrthonormalVectors,
     UnitaryVectors,
     UnitLengthVectors,
+    VectorsWithProperties,
 )
 
 
@@ -44,6 +45,17 @@ def test_expected_unit_length_vectors(rng):
     assert np.abs(np.mean([np.linalg.norm(next(g)) for i in range(50)]) - 1.0) < 0.1
 
 
+def test_vectors_with_properties(rng):
+    algebra = HrrAlgebra()
+    g = VectorsWithProperties(
+        64, {CommonProperties.POSITIVE, CommonProperties.UNITARY}, algebra, rng=rng
+    )
+    v = next(g)
+    sqrt_v = algebra.binding_power(v, 0.5)
+    assert np.allclose(v, algebra.bind(sqrt_v, sqrt_v)), "is positive"
+    assert np.allclose(algebra.make_unitary(v), v)
+
+
 @pytest.mark.parametrize(
     "vg",
     (
@@ -52,6 +64,9 @@ def test_expected_unit_length_vectors(rng):
         OrthonormalVectors,
         UnitLengthVectors,
         lambda d: UnitaryVectors(d, algebra=HrrAlgebra()),
+        lambda d: VectorsWithProperties(
+            d, {CommonProperties.POSITIVE}, algebra=HrrAlgebra()
+        ),
     ),
 )
 def test_instantiation_without_rng(vg):
@@ -67,6 +82,9 @@ def test_instantiation_without_rng(vg):
         OrthonormalVectors,
         UnitLengthVectors,
         lambda d: UnitaryVectors(d, algebra=HrrAlgebra()),
+        lambda d: VectorsWithProperties(
+            d, {CommonProperties.POSITIVE}, algebra=HrrAlgebra()
+        ),
     ),
 )
 def test_iter(vg):

--- a/nengo_spa/vector_generation.py
+++ b/nengo_spa/vector_generation.py
@@ -161,3 +161,41 @@ class ExpectedUnitLengthVectors:
 
     def next(self):
         return self.__next__()
+
+
+class VectorsWithProperties:
+    """Generator for vectors with given properties.
+
+    Supported properties depend on the algebra. See the respective algebra's
+    :meth:`.AbstractAlgebra.create_vector` method.
+
+    Parameters
+    ----------
+    d : int
+        Dimensionality of returned vectors.
+    properties
+        Properties that the generated vectors have to fulfill. Details depend
+        on the exact algebra.
+    algebra : AbstractAlgebra
+        Algebra that determines the interpretation of the properties.
+    rng : numpy.random.RandomState, optional
+        The random number generator to use to create new vectors.
+    """
+
+    def __init__(self, d, properties, algebra, *, rng=None):
+        if rng is None:
+            rng = np.random.RandomState()
+
+        self.d = d
+        self.properties = properties
+        self.algebra = algebra
+        self.rng = rng
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.algebra.create_vector(self.d, self.properties, rng=self.rng)
+
+    def next(self):
+        return self.__next__()

--- a/nengo_spa/vector_generation.py
+++ b/nengo_spa/vector_generation.py
@@ -90,6 +90,57 @@ class UnitaryVectors:
         return self.__next__()
 
 
+class EquallySpacedPositiveUnitaryHrrVectors:
+    """Generator for equally spaced positive unitary HRR vectors.
+
+    The vectors produced by this generator lie all on a hyper-circle of
+    positive, unitary vectors under the `.HrrAlgebra`. The distance from one
+    vector to the next is constant.
+
+    Note that the identity vector is included in the set of returned
+    vectors if any of the vectors hits an offset of 0. This might not be desired
+    as it will return any vector it is bound to unchanged. Use a non-integer
+    *offset* to ensure that the identity vector is not included.
+
+    Parameters
+    ----------
+    d : int
+        Dimensionality of returned vectors.
+    n : int
+        Number of vectors to fit onto the hyper-circle. At most *n* vectors
+        can be returned from the generator.
+    offset : float
+        Offset of the first returned vector along the hyper-circle. An offset
+        of 0 will return the identity vector first. An offset of 1 corresponds
+        to the vector when moving a 1/n-th part along the hyper-circle.
+
+    Attributes
+    ----------
+    vectors : (n, d) ndarray
+        All vectors that would be returned by iterating over the generator.
+    """
+
+    def __init__(self, *, d, n, offset):
+        coefficient_count = (d + 1) // 2
+        unity_roots = np.exp(
+            2.0j
+            * np.pi
+            * np.arange(start=coefficient_count, stop=d % 2 - 1, step=-1)
+            / coefficient_count
+        )
+        exponents_offset = coefficient_count / n * offset
+        exponents = np.linspace(
+            0 + exponents_offset,
+            coefficient_count + exponents_offset,
+            n,
+            endpoint=False,
+        )
+        self.vectors = np.fft.irfft(unity_roots[None, :] ** exponents[:, None], n=d)
+
+    def __iter__(self):
+        return iter(self.vectors)
+
+
 class OrthonormalVectors:
     """Generator for random orthonormal vectors.
 


### PR DESCRIPTION
**Motivation and context:**
This introduces two new vector generators based on #271.

* ``VectorsWithProperties`` adds a more convenient method to generate a larger number of vectors with desired properties (positive and/or unitary). In theory the less general ``UnitaryVectors`` generator could be implemented with the ``VectorsWithProperties``, however, this would be a breaking change because ``UnitaryVectors`` might be used with an older algebra implementation that does not implement ``create_vectors``.
* `EquallySpacedPositiveUnitaryHrrVectors` allows to create positive, unitary HRR vectors with an equal spacing around the hyper-circle those vectors lie on.

This PR closes #284.

**Interactions with other PRs:**
based on #271 
Further PRs to make the #271 features available from the `SemanticPointer` class will likely depend on this PR to have an easy method to generate desired SPs in unit tests.

**How has this been tested?**
added unit tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
