### PR TITLE
Fix VTB and TVTB definitions in the comments

### DIFF
--- a/nengo_spa/algebras/tvtb_algebra.py
+++ b/nengo_spa/algebras/tvtb_algebra.py
@@ -23,10 +23,12 @@ class TvtbAlgebra(AbstractAlgebra):
        \mathcal{B}(x, y) := V_y^T x = \left[\begin{array}{ccc}
            V_y'^T &      0 &      0 \\
               0   & V_y'^T &      0 \\
-              0   &      0 & V_y'^T
+              0   &      0 & \ddots
            \end{array}\right] x
 
-    with
+    with :math:`d'` blocks
+
+    where
 
     .. math::
 

--- a/nengo_spa/algebras/vtb_algebra.py
+++ b/nengo_spa/algebras/vtb_algebra.py
@@ -23,10 +23,12 @@ class VtbAlgebra(AbstractAlgebra):
        \mathcal{B}(x, y) := V_y x = \left[\begin{array}{ccc}
            V_y' &    0 &    0 \\
               0 & V_y' &    0 \\
-              0 &    0 & V_y'
+              0 &    0 & \ddots
            \end{array}\right] x
 
-    with
+    with :math:`d'` blocks
+
+    where
 
     .. math::
 


### PR DESCRIPTION
**Motivation and context:**
There is an error in the documentation of the vtb and Tvtb algebras.
The binding operator should have `d'` blocks and not just 3.

**Interactions with other PRs:**
Nothing that I'm aware of.

**How has this been tested?**
I've built the documentation.

**How long should this take to review?**
- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
Some comments (and the documentation) where changed.

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [ no ] I have included a changelog entry.
- [ no ] I have added tests to cover my changes.
- [ no ] I have run the test suite locally and all tests passed.

**Still to do:**
- [ ] Sign the contributor agreement?